### PR TITLE
Update post types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ sodiumoxide = "0.2.7"
 desert = "2.0.0"
 async-std = { version = "1.10.0", features = ["attributes","unstable"] }
 futures = "0.3.13"
-length-prefixed-stream = "1.0.0"
+#length-prefixed-stream = "1.0.0"
 signature = "1.3.1"
 async-trait = "0.1.51"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,11 @@
+mod post;
+
+pub type Channel = Vec<u8>;
+pub type Hash = [u8; 32];
+pub type Text = Vec<u8>;
+pub type Topic = Vec<u8>;
+
+/*
 #![feature(backtrace, async_closure, drain_filter)]
 
 use async_std::{
@@ -317,3 +325,4 @@ where
         Ok(())
     }
 }
+*/


### PR DESCRIPTION
All code except for post type definitions has been commented out and the `length-prefixed-stream` dependency has also been commented out (otherwise the crate will not compile).

All variants of the `PostBody` type are now up to date with the latest version of the spec.

Doc comments have been sourced from the spec and added throughout.

I'll work on associated methods and tests in a future PR; for now I'm just working to get the basic types up to date.