### PR TITLE
Update message types

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,9 +2,20 @@ mod message;
 mod post;
 
 pub type Channel = Vec<u8>;
+pub type CircuitId = [u8; 4];
 pub type Hash = [u8; 32];
+pub type ReqId = [u8; 4];
 pub type Text = Vec<u8>;
 pub type Topic = Vec<u8>;
+
+#[derive(Clone, Debug)]
+/// The length and data of an encoded channel name.
+pub struct EncodedChannel {
+    /// The length of the channel name in bytes.
+    pub channel_len: Vec<u8>, // varint
+    /// The channel name data.
+    pub channel: Channel,
+}
 
 /*
 #![feature(backtrace, async_closure, drain_filter)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+mod message;
 mod post;
 
 pub type Channel = Vec<u8>;

--- a/src/message.rs
+++ b/src/message.rs
@@ -1,6 +1,128 @@
+/*
 use crate::{error::CableErrorKind as E, Channel, Error, Hash, Payload, ReqId};
 use desert::{varint, CountBytes, FromBytes, ToBytes};
+*/
 
+//! Message formats for all request and response message types supported by cable.
+//!
+//! Includes type definitions for all request and response message types,
+//! as well as message header and body types. Helper methods are included.
+
+use crate::{Channel, Hash};
+
+#[derive(Clone, Debug)]
+pub struct Message {
+    pub header: MessageHeader,
+    pub body: MessageBody,
+}
+
+#[derive(Clone, Debug)]
+/// The header of a request or response message.
+pub struct MessageHeader {
+    /// Number of bytes in the rest of the message, not including the `msg_len` field.
+    pub msg_len: Vec<u8>, // varint
+    /// Type identifier for the message (controls which fields follow the header).
+    pub msg_type: Vec<u8>, // varint
+    /// ID of a circuit for an established path; `[0,0,0,0]` for no circuit (current default).
+    pub circuit_id: [u8; 4],
+    /// Unique ID of this request (randomly-assigned).
+    pub req_id: [u8; 4],
+}
+
+#[derive(Clone, Debug)]
+pub enum MessageBody {
+    Request {
+        /// Number of network hops remaining (must be between 0 and 16).
+        ttl: Vec<u8>, // varint
+        body: RequestBody,
+    },
+    //Response {
+    //    body: ResponseBody,
+    //},
+}
+
+#[derive(Clone, Debug)]
+pub enum RequestBody {
+    /// Request a set of posts by their hashes.
+    ///
+    /// Message type (`msg_type`) is `2`.
+    Post {
+        /// Number of hashes being requested.
+        hash_count: Vec<u8>, // varint
+        /// Hashes being requested (concatenated together).
+        hashes: Vec<Hash>,
+    },
+    /// Conclude a given request identified by `req_id` and stop receiving responses for that request.
+    ///
+    /// Message type (`msg_type`) is `3`.
+    Cancel {
+        /// The `req_id` of the request to be cancelled.
+        cancel_id: Vec<u8>, // varint
+    },
+    /// Request chat messages and chat message deletions written to a channel
+    /// between a start and end time, optionally subscribing to future chat messages.
+    ///
+    /// Message type (`msg_type`) is `4`.
+    ChannelTimeRange {
+        /// Length of the channel's name in bytes.
+        channel_len: Vec<u8>, // varint
+        /// Channel name (UTF-8).
+        channel: Channel,
+        /// Beginning of the time range (in milliseconds since the UNIX Epoch).
+        ///
+        /// This represents the age of the oldest post the requester is interested in.
+        time_start: Vec<u8>, // varint
+        /// End of the time range (in milliseconds since the UNIX Epoch).
+        ///
+        /// This represents the age of the newest post the requester is interested in.
+        ///
+        /// A value of `0` is a keep-alive request; the responder should continue
+        /// to send chat messages as they learn of them in the future.
+        time_end: Vec<u8>, // varint
+        /// Maximum numbers of hashes to return.
+        limit: Vec<u8>, // varint
+    },
+    /// Request posts that describe the current state of a channel and it's members,
+    /// and optionally subscribe to future state changes.
+    ///
+    /// Message type (`msg_type`) is `5`.
+    ChannelState {
+        /// Length of the channel's name in bytes.
+        channel_len: Vec<u8>, // varint
+        /// Channel name (UTF-8).
+        channel: Channel,
+        /// Whether to include live/future state hashes.
+        ///
+        /// This value must be set to either `0` or `1`.
+        ///
+        /// A value of `0` means that only the latest state posts will be included
+        /// and the request will not be held open.
+        ///
+        /// A value of `1` means that the responder will respond with future channel
+        /// state changes as they become known to the responder. The request will be
+        /// held open indefinitely on both the requester and responder side until
+        /// either a Cancel Request is issued by the requester or the responder
+        /// elects to end the request by sending a Hash Response with hash_count = 0.
+        future: Vec<u8>, // varint
+    },
+    /// Request a list of known channels from peers.
+    ///
+    /// The combination of `offset` and `limit` fields allows clients to paginate
+    /// through the list of all channel names known by a peer.
+    ///
+    /// Message type (`msg_type`) is `6`.
+    ChannelList {
+        /// Number of channel names to skip (`0` to skip none).
+        offset: Vec<u8>, // varint
+        /// Maximum number of channel names to return.
+        ///
+        /// If set to `0`, the responder must respond with all known channels
+        /// (after skipping the first `offset` entries).
+        limit: Vec<u8>, // varint
+    },
+}
+
+/*
 #[derive(Clone, Debug)]
 pub enum Message {
     HashResponse {
@@ -438,3 +560,4 @@ impl FromBytes for Message {
         })
     }
 }
+*/

--- a/src/post.rs
+++ b/src/post.rs
@@ -22,6 +22,15 @@ pub struct UserInfo {
 }
 
 #[derive(Clone, Debug)]
+/// The length and data of an encoded post.
+pub struct EncodedPost {
+    /// The length of the post in bytes.
+    pub post_len: Vec<u8>, // varint
+    /// The post data.
+    pub post_data: Vec<u8>,
+}
+
+#[derive(Clone, Debug)]
 pub struct Post {
     pub header: PostHeader,
     pub body: PostBody,

--- a/src/post.rs
+++ b/src/post.rs
@@ -28,7 +28,7 @@ pub struct Post {
 }
 
 #[derive(Clone, Debug)]
-/// The header of a post message.
+/// The header of a post.
 pub struct PostHeader {
     /// Public key that authored this post.
     pub public_key: [u8; 32],
@@ -48,7 +48,7 @@ pub struct PostHeader {
 // E.g. "A topic field MUST be a valid UTF-8 string, between 0 and 512 codepoints."
 
 #[derive(Clone, Debug)]
-/// The body of a post message.
+/// The body of a post.
 pub enum PostBody {
     /// Post a chat message to a channel.
     Text {
@@ -67,7 +67,7 @@ pub enum PostBody {
         /// Number of posts to be deleted (specified by number of hashes).
         num_deletions: Vec<u8>, // varint
         /// Concatenated hashes of posts to be deleted.
-        hashes: Vec<u8>,
+        hashes: Vec<Hash>,
     },
     /// Set public information about oneself.
     Info {


### PR DESCRIPTION
All code except for message type definitions has been commented out.

I'm leaning into a "more is better" approach when it comes to comments.

- [x] Message
  - [x] MessageHeader
  - [x] MessageBody
    - [x] RequestHeader
    - [x] RequestBody
    - [x] ResponseBody 
