### PR TITLE
Implement `ToBytes` and `CountBytes` trait impls for `Post` and test all variants

### DIFF
--- a/cable/Cargo.toml
+++ b/cable/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 sodiumoxide = "0.2.7"
-desert = "2.0.0"
+desert = { path = "../desert" }
 async-std = { version = "1.10.0", features = ["attributes","unstable"] }
 futures = "0.3.13"
 #length-prefixed-stream = "1.0.0"

--- a/cable/src/error.rs
+++ b/cable/src/error.rs
@@ -1,9 +1,12 @@
-use crate::Error;
+#[cfg(feature = "nightly-features")]
 use std::backtrace::Backtrace;
+
+pub type Error = Box<dyn std::error::Error + Send + Sync>;
 
 #[derive(Debug)]
 pub struct CableError {
     kind: CableErrorKind,
+    #[cfg(feature = "nightly-features")]
     backtrace: Backtrace,
 }
 
@@ -26,12 +29,14 @@ impl CableErrorKind {
     pub fn raise<T>(self) -> Result<T, Error> {
         Err(Box::new(CableError {
             kind: self,
+            #[cfg(feature = "nightly-features")]
             backtrace: Backtrace::capture(),
         }))
     }
 }
 
 impl std::error::Error for CableError {
+    #[cfg(feature = "nightly-features")]
     fn backtrace<'a>(&'a self) -> Option<&'a Backtrace> {
         Some(&self.backtrace)
     }

--- a/cable/src/lib.rs
+++ b/cable/src/lib.rs
@@ -3,6 +3,7 @@ mod message;
 mod post;
 
 pub type Channel = Vec<u8>;
+pub type ChannelLen = u64;
 pub type CircuitId = [u8; 4];
 pub type Hash = [u8; 32];
 pub type ReqId = [u8; 4];

--- a/cable/src/lib.rs
+++ b/cable/src/lib.rs
@@ -1,3 +1,4 @@
+mod error;
 mod message;
 mod post;
 

--- a/cable/src/lib.rs
+++ b/cable/src/lib.rs
@@ -3,7 +3,6 @@ mod message;
 mod post;
 
 pub type Channel = Vec<u8>;
-pub type ChannelLen = u64;
 pub type CircuitId = [u8; 4];
 pub type Hash = [u8; 32];
 pub type ReqId = [u8; 4];

--- a/cable/src/post.rs
+++ b/cable/src/post.rs
@@ -128,12 +128,8 @@ pub enum PostBody {
     },
     /// Set a topic for a channel.
     Topic {
-        /// Length of the channel's name in bytes.
-        channel_len: ChannelLen,
         /// Channel name (UTF-8).
         channel: Channel,
-        /// Length of the topic field in bytes.
-        topic_len: u64,
         /// Topic content (UTF-8).
         topic: Topic,
     },
@@ -285,18 +281,10 @@ impl ToBytes for Post {
                     offset += val.len();
                 }
             }
-            PostBody::Topic {
-                channel_len,
-                channel,
-                topic_len,
-                topic,
-            } => {
-                offset += varint::encode(*channel_len, &mut buf[offset..])?;
+            PostBody::Topic { channel, topic } => {
+                offset += varint::encode(channel.len() as u64, &mut buf[offset..])?;
                 buf[offset..offset + channel.len()].copy_from_slice(channel);
                 offset += channel.len();
-                offset += varint::encode(*topic_len, &mut buf[offset..])?;
-                // TODO: Check that this line is necessary; may be made
-                // redundant by previous LOC.
                 offset += varint::encode(topic.len() as u64, &mut buf[offset..])?;
                 buf[offset..offset + topic.len()].copy_from_slice(topic);
                 offset += topic.len();
@@ -364,15 +352,10 @@ impl CountBytes for Post {
 
                 info_len
             }
-            PostBody::Topic {
-                channel_len,
-                channel,
-                topic_len,
-                topic,
-            } => {
-                varint::length(*channel_len)
+            PostBody::Topic { channel, topic } => {
+                varint::length(channel.len() as u64)
                     + channel.len()
-                    + varint::length(*topic_len)
+                    + varint::length(topic.len() as u64)
                     + topic.len()
             }
             PostBody::Join {

--- a/cable/src/post.rs
+++ b/cable/src/post.rs
@@ -135,15 +135,11 @@ pub enum PostBody {
     },
     /// Publicly announce membership in a channel.
     Join {
-        /// Length of the channel's name in bytes.
-        channel_len: ChannelLen,
         /// Channel name (UTF-8).
         channel: Channel,
     },
     /// Publicly announce termination of membership in a channel.
     Leave {
-        /// Length of the channel's name in bytes.
-        channel_len: ChannelLen,
         /// Channel name (UTF-8).
         channel: Channel,
     },
@@ -289,19 +285,13 @@ impl ToBytes for Post {
                 buf[offset..offset + topic.len()].copy_from_slice(topic);
                 offset += topic.len();
             }
-            PostBody::Join {
-                channel_len,
-                channel,
-            } => {
-                offset += varint::encode(*channel_len, &mut buf[offset..])?;
+            PostBody::Join { channel } => {
+                offset += varint::encode(channel.len() as u64, &mut buf[offset..])?;
                 buf[offset..offset + channel.len()].copy_from_slice(channel);
                 offset += channel.len();
             }
-            PostBody::Leave {
-                channel_len,
-                channel,
-            } => {
-                offset += varint::encode(*channel_len, &mut buf[offset..])?;
+            PostBody::Leave { channel } => {
+                offset += varint::encode(channel.len() as u64, &mut buf[offset..])?;
                 buf[offset..offset + channel.len()].copy_from_slice(channel);
                 offset += channel.len();
             }
@@ -358,14 +348,8 @@ impl CountBytes for Post {
                     + varint::length(topic.len() as u64)
                     + topic.len()
             }
-            PostBody::Join {
-                channel_len,
-                channel,
-            } => varint::length(*channel_len) + channel.len(),
-            PostBody::Leave {
-                channel_len,
-                channel,
-            } => varint::length(*channel_len) + channel.len(),
+            PostBody::Join { channel } => varint::length(channel.len() as u64) + channel.len(),
+            PostBody::Leave { channel } => varint::length(channel.len() as u64) + channel.len(),
             PostBody::Unrecognized { .. } => 0,
         };
 

--- a/cable/src/post.rs
+++ b/cable/src/post.rs
@@ -18,15 +18,15 @@ use sodiumoxide::crypto::{
 
 use crate::{
     error::{CableErrorKind, Error},
-    Channel, Hash, Text, Topic,
+    Channel, ChannelLen, Hash, Text, Topic,
 };
 
 #[derive(Clone, Debug)]
 /// Information self-published by a user.
 pub struct UserInfo {
-    pub key_len: Vec<u8>, // varint
+    pub key_len: u64, // varint
     pub key: Vec<u8>,
-    pub val_len: Vec<u8>, // varint
+    pub val_len: u64, // varint
     pub val: Vec<u8>,
 }
 
@@ -34,7 +34,7 @@ pub struct UserInfo {
 /// The length and data of an encoded post.
 pub struct EncodedPost {
     /// The length of the post in bytes.
-    pub post_len: Vec<u8>, // varint
+    pub post_len: u64, // varint
     /// The post data.
     pub post_data: Vec<u8>,
 }
@@ -45,6 +45,9 @@ pub struct Post {
     pub body: PostBody,
 }
 
+// TODO: think about appropriate integer sizes.
+// E.g. Should `num_links` and `post_type` be `u64` or smaller?
+
 #[derive(Clone, Debug)]
 /// The header of a post.
 pub struct PostHeader {
@@ -53,13 +56,16 @@ pub struct PostHeader {
     /// Signature of the fields that follow.
     pub signature: [u8; 64],
     /// Number of hashes this post links back to (0+).
-    pub num_links: Vec<u8>, // varint
+    // TODO: Consider removing `varint` comments; may be confusing.
+    // These fields are eventually encoded as `varint` but are not expressed in
+    // that form when decoded.
+    pub num_links: u64, // varint
     /// Hashes of the latest posts in this channel/context.
-    pub links: Vec<u8>,
+    pub links: Vec<Hash>,
     /// Post type.
-    pub post_type: Vec<u8>, // varint
+    pub post_type: u64, // varint
     /// Time at which the post was created (in milliseconds since the UNIX Epoch).
-    pub timestamp: Vec<u8>, // varint
+    pub timestamp: u64, // varint
 }
 
 // TODO: remember to write validators for post type data.
@@ -71,11 +77,11 @@ pub enum PostBody {
     /// Post a chat message to a channel.
     Text {
         /// Length of the channel's name in bytes.
-        channel_len: Vec<u8>, // varint
+        channel_len: ChannelLen, // varint
         /// Channel name (UTF-8).
         channel: Channel,
         /// Length of the text field in bytes.
-        text_len: Vec<u8>, // varint
+        text_len: u64, // varint
         /// Chat message text (UTF-8).
         text: Text,
     },
@@ -83,7 +89,7 @@ pub enum PostBody {
     /// from their local storage, and not store the referenced posts in the future.
     Delete {
         /// Number of posts to be deleted (specified by number of hashes).
-        num_deletions: Vec<u8>, // varint
+        num_deletions: u64, // varint
         /// Concatenated hashes of posts to be deleted.
         hashes: Vec<Hash>,
     },
@@ -95,25 +101,25 @@ pub enum PostBody {
     /// Set a topic for a channel.
     Topic {
         /// Length of the channel's name in bytes.
-        channel_len: Vec<u8>, // varint
+        channel_len: ChannelLen, // varint
         /// Channel name (UTF-8).
         channel: Channel,
         /// Length of the topic field in bytes.
-        topic_len: Vec<u8>, // varint
+        topic_len: u64, // varint
         /// Topic content (UTF-8).
         topic: Topic,
     },
     /// Publicly announce membership in a channel.
     Join {
         /// Length of the channel's name in bytes.
-        channel_len: Vec<u8>, // varint
+        channel_len: ChannelLen, // varint
         /// Channel name (UTF-8).
         channel: Channel,
     },
     /// Publicly announce termination of membership in a channel.
     Leave {
         /// Length of the channel's name in bytes.
-        channel_len: Vec<u8>, // varint
+        channel_len: ChannelLen, // varint
         /// Channel name (UTF-8).
         channel: Channel,
     },

--- a/cable/src/post.rs
+++ b/cable/src/post.rs
@@ -368,10 +368,11 @@ mod test {
     use hex::FromHex;
 
     const PUBLIC_KEY: &str = "25b272a71555322d40efe449a7f99af8fd364b92d350f1664481b2da340a02d0";
+    const POST_HASH: &str = "5049d089a650aa896cb25ec35258653be4df196b4a5e5b6db7ed024aaa89e1b3";
     const TEXT_POST_HEX_BINARY: &str = "25b272a71555322d40efe449a7f99af8fd364b92d350f1664481b2da340a02d06725733046b35fa3a7e8dc0099a2b3dff10d3fd8b0f6da70d094352e3f5d27a8bc3f5586cf0bf71befc22536c3c50ec7b1d64398d43c3f4cde778e579e88af05015049d089a650aa896cb25ec35258653be4df196b4a5e5b6db7ed024aaa89e1b300500764656661756c740d68e282ac6c6c6f20776f726c64";
     const DELETE_POST_HEX_BINARY: &str = "25b272a71555322d40efe449a7f99af8fd364b92d350f1664481b2da340a02d0affe77e3b3156cda7feea042269bb7e93f5031662c70610d37baa69132b4150c18d67cb2ac24fb0f9be0a6516e53ba2f3bbc5bd8e7a1bff64d9c78ce0c2e4205015049d089a650aa896cb25ec35258653be4df196b4a5e5b6db7ed024aaa89e1b301500315ed54965515babf6f16be3f96b04b29ecca813a343311dae483691c07ccf4e597fc63631c41384226b9b68d9f73ffaaf6eac54b71838687f48f112e30d6db689c2939fec6d47b00bafe6967aeff697cf4b5abca01b04ba1b31a7e3752454bfa";
     const INFO_POST_HEX_BINARY: &str = "25b272a71555322d40efe449a7f99af8fd364b92d350f1664481b2da340a02d0f70273779147a3b756407d5660ed2e8e2975abc5ab224fb152aa2bfb3dd331740a66e0718cd580bc94978c1c3cd4524ad8cb2f4cca80df481010c3ef834ac700015049d089a650aa896cb25ec35258653be4df196b4a5e5b6db7ed024aaa89e1b30250046e616d65066361626c6572";
-    const POST_HASH: &str = "5049d089a650aa896cb25ec35258653be4df196b4a5e5b6db7ed024aaa89e1b3";
+    const TOPIC_POST_HEX_BINARY: &str = "25b272a71555322d40efe449a7f99af8fd364b92d350f1664481b2da340a02d0bf7578e781caee4ca708281645b291a2100c4f2138f0e0ac98bc2b4a414b4ba8dca08285751114b05f131421a1745b648c43b17b05392593237dfacc8dff5208015049d089a650aa896cb25ec35258653be4df196b4a5e5b6db7ed024aaa89e1b303500764656661756c743b696e74726f6475636520796f757273656c6620746f2074686520667269656e646c792063726f7764206f66206c696b656d696e64656420666f6c78";
 
     #[test]
     fn verify_post() {
@@ -396,13 +397,13 @@ mod test {
         let post_type = 0;
         let timestamp = 80;
 
+        // Construct a new post header.
+        let header = PostHeader::new(public_key, signature, links, post_type, timestamp);
+
         /* BODY FIELD VALUES */
 
         let channel: Vec<u8> = "default".to_string().into();
         let text: Vec<u8> = "h€llo world".to_string().into();
-
-        // Construct a new post header.
-        let header = PostHeader::new(public_key, signature, links, post_type, timestamp);
 
         // Construct a new post body.
         let body = PostBody::Text { channel, text };
@@ -433,6 +434,9 @@ mod test {
         let post_type = 1;
         let timestamp = 80;
 
+        // Construct a new post header.
+        let header = PostHeader::new(public_key, signature, links, post_type, timestamp);
+
         /* BODY FIELD VALUES */
 
         // Concatenate the hashes into a single `Vec<u8>`.
@@ -451,9 +455,6 @@ mod test {
             )
             .unwrap(),
         );
-
-        // Construct a new post header.
-        let header = PostHeader::new(public_key, signature, links, post_type, timestamp);
 
         // Construct a new post body.
         let body = PostBody::Delete { hashes };
@@ -474,25 +475,6 @@ mod test {
         assert_eq!(expected_bytes, post_bytes);
     }
 
-    /*
-        {
-      "name": "post/info",
-      "type": "post",
-      "id": 2,
-      "binary": "25b272a71555322d40efe449a7f99af8fd364b92d350f1664481b2da340a02d0f70273779147a3b756407d5660ed2e8e2975abc5ab224fb152aa2bfb3dd331740a66e0718cd580bc94978c1c3cd4524ad8cb2f4cca80df481010c3ef834ac700015049d089a650aa896cb25ec35258653be4df196b4a5e5b6db7ed024aaa89e1b30250046e616d65066361626c6572",
-      "obj": {
-        "publicKey": "25b272a71555322d40efe449a7f99af8fd364b92d350f1664481b2da340a02d0",
-        "signature": "f70273779147a3b756407d5660ed2e8e2975abc5ab224fb152aa2bfb3dd331740a66e0718cd580bc94978c1c3cd4524ad8cb2f4cca80df481010c3ef834ac700",
-        "links": [
-          "5049d089a650aa896cb25ec35258653be4df196b4a5e5b6db7ed024aaa89e1b3"
-        ],
-        "postType": 2,
-        "timestamp": 80,
-        "key": "name",
-        "value": "cabler"
-      }
-    }
-        */
     #[test]
     fn info_post_to_bytes() {
         /* HEADER FIELD VALUES */
@@ -503,13 +485,14 @@ mod test {
         let post_type = 2;
         let timestamp = 80;
 
+        // Construct a new post header.
+        let header = PostHeader::new(public_key, signature, links, post_type, timestamp);
+
         /* BODY FIELD VALUES */
+
         let key = "name".to_string();
         let val = "cabler".to_string();
         let user_info = UserInfo::new(key, val);
-
-        // Construct a new post header.
-        let header = PostHeader::new(public_key, signature, links, post_type, timestamp);
 
         // Construct a new post body.
         let body = PostBody::Info {
@@ -523,6 +506,65 @@ mod test {
 
         // Test vector binary.
         let expected_bytes = <Vec<u8>>::from_hex(INFO_POST_HEX_BINARY).unwrap();
+
+        // Ensure the number of generated post bytes matches the number of
+        // expected bytes.
+        assert_eq!(expected_bytes.len(), post_bytes.len());
+
+        // Ensure the generated post bytes match the expected bytes.
+        assert_eq!(expected_bytes, post_bytes);
+    }
+
+    /*
+        {
+      "name": "post/topic",
+      "type": "post",
+      "id": 3,
+      "binary": "25b272a71555322d40efe449a7f99af8fd364b92d350f1664481b2da340a02d0bf7578e781caee4ca708281645b291a2100c4f2138f0e0ac98bc2b4a414b4ba8dca08285751114b05f131421a1745b648c43b17b05392593237dfacc8dff5208015049d089a650aa896cb25ec35258653be4df196b4a5e5b6db7ed024aaa89e1b303500764656661756c743b696e74726f6475636520796f757273656c6620746f2074686520667269656e646c792063726f7764206f66206c696b656d696e64656420666f6c78",
+      "obj": {
+        "publicKey": "25b272a71555322d40efe449a7f99af8fd364b92d350f1664481b2da340a02d0",
+        "signature": "bf7578e781caee4ca708281645b291a2100c4f2138f0e0ac98bc2b4a414b4ba8dca08285751114b05f131421a1745b648c43b17b05392593237dfacc8dff5208",
+        "links": [
+          "5049d089a650aa896cb25ec35258653be4df196b4a5e5b6db7ed024aaa89e1b3"
+        ],
+        "postType": 3,
+        "channel": "default",
+        "timestamp": 80,
+        "topic": "introduce yourself to the friendly crowd of likeminded folx"
+      }
+    }
+        */
+    #[test]
+    fn topic_post_to_bytes() {
+        /* HEADER FIELD VALUES */
+
+        let public_key = <[u8; 32]>::from_hex(PUBLIC_KEY).unwrap();
+        let signature = <[u8; 64]>::from_hex("bf7578e781caee4ca708281645b291a2100c4f2138f0e0ac98bc2b4a414b4ba8dca08285751114b05f131421a1745b648c43b17b05392593237dfacc8dff5208").unwrap();
+        let links = <Vec<u8>>::from_hex(POST_HASH).unwrap();
+        let post_type = 3;
+        let timestamp = 80;
+
+        // Construct a new post header.
+        let header = PostHeader::new(public_key, signature, links, post_type, timestamp);
+
+        /* BODY FIELD VALUES */
+
+        let channel = "default".to_string();
+        let topic = "introduce yourself to the friendly crowd of likeminded folx".to_string();
+
+        // Construct a new post body.
+        let body = PostBody::Topic {
+            channel: channel.into(),
+            topic: topic.into(),
+        };
+
+        // Construct a new post.
+        let post = Post::new(header, body);
+        // Convert the post to bytes.
+        let post_bytes = post.to_bytes().unwrap();
+
+        // Test vector binary.
+        let expected_bytes = <Vec<u8>>::from_hex(TOPIC_POST_HEX_BINARY).unwrap();
 
         // Ensure the number of generated post bytes matches the number of
         // expected bytes.

--- a/cable/src/post.rs
+++ b/cable/src/post.rs
@@ -18,7 +18,7 @@ use sodiumoxide::crypto::{
 
 use crate::{
     error::{CableErrorKind, Error},
-    Channel, ChannelLen, Hash, Text, Topic,
+    Channel, Hash, Text, Topic,
 };
 
 #[derive(Clone, Debug)]

--- a/cable/src/post.rs
+++ b/cable/src/post.rs
@@ -10,12 +10,16 @@ use std::convert::TryInto;
 //! Includes type definitions for all post types, as well as post header and
 //! body types. Helper methods are included.
 
+use desert::{varint, CountBytes, FromBytes, ToBytes};
 use sodiumoxide::crypto::{
     sign,
-    sign::{PublicKey, Signature},
+    sign::{PublicKey, SecretKey, Signature},
 };
 
-use crate::{Channel, Hash, Text, Topic};
+use crate::{
+    error::{CableErrorKind, Error},
+    Channel, Hash, Text, Topic,
+};
 
 #[derive(Clone, Debug)]
 /// Information self-published by a user.
@@ -48,7 +52,7 @@ pub struct PostHeader {
     pub public_key: [u8; 32],
     /// Signature of the fields that follow.
     pub signature: [u8; 64],
-    /// Number of hashes this post links back to you (0+).
+    /// Number of hashes this post links back to (0+).
     pub num_links: Vec<u8>, // varint
     /// Hashes of the latest posts in this channel/context.
     pub links: Vec<u8>,
@@ -144,6 +148,14 @@ impl Post {
         }
     }
 
+    pub fn sign(&mut self, secret_key: &[u8; 64]) -> Result<(), Error> {
+        let buf = self.to_bytes()?;
+        let sk = SecretKey::from_slice(secret_key).unwrap();
+        // todo: return NoneError
+        self.header.signature = sign::sign_detached(&buf[32 + 64..], &sk).to_bytes();
+        Ok(())
+    }
+
     /// Verify the signature of an encoded post.
     pub fn verify(buf: &[u8]) -> bool {
         // Since the public key is 32 bytes and the signature is 64 bytes,
@@ -161,6 +173,290 @@ impl Post {
         }
     }
 }
+
+impl ToBytes for Post {
+    /// Convert a `Post` data type to bytes.
+    fn to_bytes(&self) -> Result<Vec<u8>, Error> {
+        let mut buf = vec![0; self.count_bytes()];
+        self.write_bytes(&mut buf)?;
+        Ok(buf)
+    }
+
+    /// Write bytes to the given buffer (mutable byte array).
+    fn write_bytes(&self, buf: &mut [u8]) -> Result<usize, Error> {
+        let mut offset = 0;
+
+        // Validate the length of the public key, signature and links fields.
+        assert_eq![self.header.public_key.len(), 32];
+        assert_eq![self.header.signature.len(), 64];
+        // The links field should be an exact multiple of 32 (32 bytes per
+        // link).
+        assert_eq![self.header.links.len() % 32, 0];
+
+        // Write the public key bytes to the buffer and increment the offset.
+        buf[offset..offset + 32].copy_from_slice(&self.header.public_key);
+        offset += self.header.public_key.len();
+
+        // Write the signature bytes to the buffer and increment the offset.
+        buf[offset..offset + 64].copy_from_slice(&self.header.signature);
+        offset += self.header.signature.len();
+
+        // Encode num_links as a varint, write the resulting bytes to the
+        // buffer and increment the offset.
+        offset += varint::encode(self.header.num_links.len() as u64, &mut buf[offset..])?;
+
+        // Write the links bytes to the buffer and increment the offset.
+        buf[offset..offset + self.header.num_links].copy_from_slice(&self.header.links);
+        offset += self.header.links.len();
+
+        // Encode the post type as a varint, write the resulting bytes to the
+        // buffer and increment the offset.
+        offset += varint::encode(self.post_type(), &mut buf[offset..])?;
+
+        // Encode the timestamp as a varint, write the resulting bytes to the
+        // buffer and increment the offset.
+        offset += varint::encode(self.header.timestamp as u64, &mut buf[offset..])?;
+
+        match &self.body {
+            PostBody::Text {
+                channel,
+                timestamp,
+                text,
+            } => {
+                offset += varint::encode(channel.len() as u64, &mut buf[offset..])?;
+                buf[offset..offset + channel.len()].copy_from_slice(channel);
+                offset += channel.len();
+                offset += varint::encode(*timestamp, &mut buf[offset..])?;
+                offset += varint::encode(text.len() as u64, &mut buf[offset..])?;
+                buf[offset..offset + text.len()].copy_from_slice(text);
+                offset += text.len();
+            }
+            PostBody::Delete { timestamp, hash } => {
+                offset += varint::encode(*timestamp, &mut buf[offset..])?;
+                buf[offset..offset + hash.len()].copy_from_slice(hash);
+                offset += hash.len();
+            }
+            PostBody::Info {
+                timestamp,
+                key,
+                value,
+            } => {
+                offset += varint::encode(*timestamp, &mut buf[offset..])?;
+                offset += varint::encode(key.len() as u64, &mut buf[offset..])?;
+                buf[offset..offset + key.len()].copy_from_slice(key);
+                offset += key.len();
+                offset += varint::encode(value.len() as u64, &mut buf[offset..])?;
+                buf[offset..offset + value.len()].copy_from_slice(value);
+                offset += value.len();
+            }
+            PostBody::Topic {
+                channel,
+                timestamp,
+                topic,
+            } => {
+                offset += varint::encode(channel.len() as u64, &mut buf[offset..])?;
+                buf[offset..offset + channel.len()].copy_from_slice(channel);
+                offset += channel.len();
+                offset += varint::encode(*timestamp, &mut buf[offset..])?;
+                offset += varint::encode(topic.len() as u64, &mut buf[offset..])?;
+                buf[offset..offset + topic.len()].copy_from_slice(topic);
+                offset += topic.len();
+            }
+            PostBody::Join { channel, timestamp } => {
+                offset += varint::encode(channel.len() as u64, &mut buf[offset..])?;
+                buf[offset..offset + channel.len()].copy_from_slice(channel);
+                offset += channel.len();
+                offset += varint::encode(*timestamp, &mut buf[offset..])?;
+            }
+            PostBody::Leave { channel, timestamp } => {
+                offset += varint::encode(channel.len() as u64, &mut buf[offset..])?;
+                buf[offset..offset + channel.len()].copy_from_slice(channel);
+                offset += channel.len();
+                offset += varint::encode(*timestamp, &mut buf[offset..])?;
+            }
+            PostBody::Unrecognized { post_type } => {
+                return CableErrorKind::PostWriteUnrecognizedType {
+                    post_type: *post_type,
+                }
+                .raise();
+            }
+        }
+        Ok(offset)
+    }
+}
+
+/*
+impl CountBytes for Post {
+    fn count_bytes(&self) -> usize {
+        let post_type = self.post_type();
+
+        let header_size = 32
+            + 64
+            + varint::length(self.header.num_links.len() as u64)
+            + 32 * self.header.num_links.len()
+            + varint::length(post_type)
+            + varint::length(self.header.timestamp);
+
+        let body_size = varint::length(post_type)
+            + match &self.body {
+                PostBody::Text {
+                    channel,
+                    timestamp,
+                    text,
+                } => {
+                    varint::length(channel.len() as u64)
+                        + channel.len()
+                        + varint::length(*timestamp)
+                        + varint::length(text.len() as u64)
+                        + text.len()
+                }
+                PostBody::Delete { timestamp, hash } => varint::length(*timestamp) + hash.len(),
+                PostBody::Info {
+                    timestamp,
+                    key,
+                    value,
+                } => {
+                    varint::length(*timestamp)
+                        + varint::length(key.len() as u64)
+                        + key.len()
+                        + varint::length(value.len() as u64)
+                        + value.len()
+                }
+                PostBody::Topic {
+                    channel,
+                    timestamp,
+                    topic,
+                } => {
+                    varint::length(channel.len() as u64)
+                        + channel.len()
+                        + varint::length(*timestamp)
+                        + varint::length(topic.len() as u64)
+                        + topic.len()
+                }
+                PostBody::Join { channel, timestamp } => {
+                    varint::length(channel.len() as u64)
+                        + channel.len()
+                        + varint::length(*timestamp)
+                }
+                PostBody::Leave { channel, timestamp } => {
+                    varint::length(channel.len() as u64)
+                        + channel.len()
+                        + varint::length(*timestamp)
+                }
+                PostBody::Unrecognized { .. } => 0,
+            };
+        header_size + body_size
+    }
+    fn count_from_bytes(_buf: &[u8]) -> Result<usize, Error> {
+        unimplemented![]
+    }
+}
+
+impl FromBytes for Post {
+    fn from_bytes(buf: &[u8]) -> Result<(usize, Self), Error> {
+        let mut offset = 0;
+        let header = {
+            let mut public_key = [0; 32];
+            public_key.copy_from_slice(&buf[offset..offset + 32]);
+            offset += 32;
+            let mut signature = [0; 64];
+            signature.copy_from_slice(&buf[offset..offset + 64]);
+            offset += 64;
+            let mut link = [0; 32];
+            link.copy_from_slice(&buf[offset..offset + 32]);
+            offset += 32;
+            PostHeader {
+                public_key,
+                signature,
+                link,
+            }
+        };
+        let (s, post_type) = varint::decode(&buf[offset..])?;
+        offset += s;
+        let body = match post_type {
+            0 => {
+                let (s, channel_len) = varint::decode(&buf[offset..])?;
+                offset += s;
+                let channel = buf[offset..offset + channel_len as usize].to_vec();
+                offset += channel_len as usize;
+                let (s, timestamp) = varint::decode(&buf[offset..])?;
+                offset += s;
+                let (s, text_len) = varint::decode(&buf[offset..])?;
+                offset += s;
+                let text = buf[offset..offset + text_len as usize].to_vec();
+                offset += text_len as usize;
+                PostBody::Text {
+                    channel,
+                    timestamp,
+                    text,
+                }
+            }
+            1 => {
+                let (s, timestamp) = varint::decode(&buf[offset..])?;
+                offset += s;
+                let mut hash = [0; 32];
+                hash.copy_from_slice(&buf[offset..offset + 32]);
+                offset += 32;
+                PostBody::Delete { timestamp, hash }
+            }
+            2 => {
+                let (s, timestamp) = varint::decode(&buf[offset..])?;
+                offset += s;
+                let (s, key_len) = varint::decode(&buf[offset..])?;
+                offset += s;
+                let key = buf[offset..offset + key_len as usize].to_vec();
+                offset += key_len as usize;
+                let (s, value_len) = varint::decode(&buf[offset..])?;
+                offset += s;
+                let value = buf[offset..offset + value_len as usize].to_vec();
+                offset += value_len as usize;
+                PostBody::Info {
+                    timestamp,
+                    key,
+                    value,
+                }
+            }
+            3 => {
+                let (s, channel_len) = varint::decode(&buf[offset..])?;
+                offset += s;
+                let channel = buf[offset..offset + channel_len as usize].to_vec();
+                offset += channel_len as usize;
+                let (s, timestamp) = varint::decode(&buf[offset..])?;
+                offset += s;
+                let (s, topic_len) = varint::decode(&buf[offset..])?;
+                offset += s;
+                let topic = buf[offset..offset + topic_len as usize].to_vec();
+                offset += topic_len as usize;
+                PostBody::Topic {
+                    channel,
+                    timestamp,
+                    topic,
+                }
+            }
+            4 => {
+                let (s, channel_len) = varint::decode(&buf[offset..])?;
+                offset += s;
+                let channel = buf[offset..offset + channel_len as usize].to_vec();
+                offset += channel_len as usize;
+                let (s, timestamp) = varint::decode(&buf[offset..])?;
+                offset += s;
+                PostBody::Join { channel, timestamp }
+            }
+            5 => {
+                let (s, channel_len) = varint::decode(&buf[offset..])?;
+                offset += s;
+                let channel = buf[offset..offset + channel_len as usize].to_vec();
+                offset += channel_len as usize;
+                let (s, timestamp) = varint::decode(&buf[offset..])?;
+                offset += s;
+                PostBody::Leave { channel, timestamp }
+            }
+            post_type => PostBody::Unrecognized { post_type },
+        };
+        Ok((offset, Post { header, body }))
+    }
+}
+*/
 
 #[cfg(test)]
 mod test {

--- a/cable/src/post.rs
+++ b/cable/src/post.rs
@@ -367,6 +367,8 @@ mod test {
 
     use hex::FromHex;
 
+    // Field values sourced from https://github.com/cabal-club/cable.js#examples.
+
     const PUBLIC_KEY: &str = "25b272a71555322d40efe449a7f99af8fd364b92d350f1664481b2da340a02d0";
     const POST_HASH: &str = "5049d089a650aa896cb25ec35258653be4df196b4a5e5b6db7ed024aaa89e1b3";
     const TEXT_POST_HEX_BINARY: &str = "25b272a71555322d40efe449a7f99af8fd364b92d350f1664481b2da340a02d06725733046b35fa3a7e8dc0099a2b3dff10d3fd8b0f6da70d094352e3f5d27a8bc3f5586cf0bf71befc22536c3c50ec7b1d64398d43c3f4cde778e579e88af05015049d089a650aa896cb25ec35258653be4df196b4a5e5b6db7ed024aaa89e1b300500764656661756c740d68e282ac6c6c6f20776f726c64";
@@ -374,6 +376,7 @@ mod test {
     const INFO_POST_HEX_BINARY: &str = "25b272a71555322d40efe449a7f99af8fd364b92d350f1664481b2da340a02d0f70273779147a3b756407d5660ed2e8e2975abc5ab224fb152aa2bfb3dd331740a66e0718cd580bc94978c1c3cd4524ad8cb2f4cca80df481010c3ef834ac700015049d089a650aa896cb25ec35258653be4df196b4a5e5b6db7ed024aaa89e1b30250046e616d65066361626c6572";
     const TOPIC_POST_HEX_BINARY: &str = "25b272a71555322d40efe449a7f99af8fd364b92d350f1664481b2da340a02d0bf7578e781caee4ca708281645b291a2100c4f2138f0e0ac98bc2b4a414b4ba8dca08285751114b05f131421a1745b648c43b17b05392593237dfacc8dff5208015049d089a650aa896cb25ec35258653be4df196b4a5e5b6db7ed024aaa89e1b303500764656661756c743b696e74726f6475636520796f757273656c6620746f2074686520667269656e646c792063726f7764206f66206c696b656d696e64656420666f6c78";
     const JOIN_POST_HEX_BINARY: &str = "25b272a71555322d40efe449a7f99af8fd364b92d350f1664481b2da340a02d064425f10fa34c1e14b6101491772d3c5f15f720a952dd56c27d5ad52f61f695130ce286de73e332612b36242339b61c9e12397f5dcc94c79055c7e1cb1dbfb08015049d089a650aa896cb25ec35258653be4df196b4a5e5b6db7ed024aaa89e1b304500764656661756c74";
+    const LEAVE_POST_HEX_BINARY: &str = "25b272a71555322d40efe449a7f99af8fd364b92d350f1664481b2da340a02d0abb083ecdca569f064564942ddf1944fbf550dc27ea36a7074be798d753cb029703de77b1a9532b6ca2ec5706e297dce073d6e508eeb425c32df8431e4677805015049d089a650aa896cb25ec35258653be4df196b4a5e5b6db7ed024aaa89e1b305500764656661756c74";
 
     #[test]
     fn verify_post() {
@@ -387,8 +390,6 @@ mod test {
     #[test]
     fn text_post_to_bytes() {
         // TODO: Return `Result` and replace `unwrap()` with `?`.
-
-        // Field values sourced from https://github.com/cabal-club/cable.js#examples.
 
         /* HEADER FIELD VALUES */
 
@@ -585,6 +586,44 @@ mod test {
 
         // Test vector binary.
         let expected_bytes = <Vec<u8>>::from_hex(JOIN_POST_HEX_BINARY).unwrap();
+
+        // Ensure the number of generated post bytes matches the number of
+        // expected bytes.
+        assert_eq!(expected_bytes.len(), post_bytes.len());
+
+        // Ensure the generated post bytes match the expected bytes.
+        assert_eq!(expected_bytes, post_bytes);
+    }
+
+    #[test]
+    fn leave_post_to_bytes() {
+        /* HEADER FIELD VALUES */
+
+        let public_key = <[u8; 32]>::from_hex(PUBLIC_KEY).unwrap();
+        let signature = <[u8; 64]>::from_hex("abb083ecdca569f064564942ddf1944fbf550dc27ea36a7074be798d753cb029703de77b1a9532b6ca2ec5706e297dce073d6e508eeb425c32df8431e4677805").unwrap();
+        let links = <Vec<u8>>::from_hex(POST_HASH).unwrap();
+        let post_type = 5;
+        let timestamp = 80;
+
+        // Construct a new post header.
+        let header = PostHeader::new(public_key, signature, links, post_type, timestamp);
+
+        /* BODY FIELD VALUES */
+
+        let channel = "default".to_string();
+
+        // Construct a new post body.
+        let body = PostBody::Leave {
+            channel: channel.into(),
+        };
+
+        // Construct a new post.
+        let post = Post::new(header, body);
+        // Convert the post to bytes.
+        let post_bytes = post.to_bytes().unwrap();
+
+        // Test vector binary.
+        let expected_bytes = <Vec<u8>>::from_hex(LEAVE_POST_HEX_BINARY).unwrap();
 
         // Ensure the number of generated post bytes matches the number of
         // expected bytes.

--- a/cable/src/post.rs
+++ b/cable/src/post.rs
@@ -55,8 +55,7 @@ pub struct PostHeader {
     pub public_key: [u8; 32],
     /// Signature of the fields that follow.
     pub signature: [u8; 64],
-    // TODO: Consider removing this field.
-    // Can be inferred from `links`.
+    // TODO: Remove this field. Can be calculated from the length of `links`.
     /// Number of hashes this post links back to (0+).
     pub num_links: u64,
     /// Hashes of the latest posts in this channel/context.
@@ -102,10 +101,12 @@ impl PostHeader {
 pub enum PostBody {
     /// Post a chat message to a channel.
     Text {
+        // TODO: Remove this field. Can be calculated from the length of `channel`.
         /// Length of the channel's name in bytes.
         channel_len: ChannelLen,
         /// Channel name (UTF-8).
         channel: Channel,
+        // TODO: Remove this field. Can be calculated from the length of `text`.
         /// Length of the text field in bytes.
         text_len: u64,
         /// Chat message text (UTF-8).
@@ -450,7 +451,7 @@ mod test {
 
     #[test]
     fn text_post_to_bytes() {
-        // TODO: Return `Result` so and replace `unwrap()` with `?`.
+        // TODO: Return `Result` and replace `unwrap()` with `?`.
 
         // Field values sourced from https://github.com/cabal-club/cable.js#examples.
 
@@ -562,218 +563,6 @@ mod test {
 }
 
 /*
-impl Post {
-    pub fn post_type(&self) -> u64 {
-        match &self.body {
-            PostBody::Text { .. } => 0,
-            PostBody::Delete { .. } => 1,
-            PostBody::Info { .. } => 2,
-            PostBody::Topic { .. } => 3,
-            PostBody::Join { .. } => 4,
-            PostBody::Leave { .. } => 5,
-            PostBody::Unrecognized { post_type } => *post_type,
-        }
-    }
-    pub fn verify(buf: &[u8]) -> bool {
-        if buf.len() < 32 + 64 {
-            return false;
-        }
-        let o_pk = crypto::sign::PublicKey::from_slice(&buf[0..32]);
-        let o_sig = crypto::sign::Signature::from_bytes(&buf[32..32 + 64]);
-        match (o_pk, o_sig) {
-            (Some(pk), Ok(sig)) => crypto::sign::verify_detached(&sig, &buf[32 + 64..], &pk),
-            _ => false,
-        }
-    }
-    pub fn sign(&mut self, secret_key: &[u8; 64]) -> Result<(), Error> {
-        let buf = self.to_bytes()?;
-        let sk = crypto::sign::SecretKey::from_slice(secret_key).unwrap();
-        // todo: return NoneError
-        self.header.signature = crypto::sign::sign_detached(&buf[32 + 64..], &sk).to_bytes();
-        Ok(())
-    }
-    pub fn is_signed(&self) -> bool {
-        for i in 0..self.header.signature.len() {
-            if self.header.signature[i] != 0 {
-                return true;
-            }
-        }
-        return false;
-    }
-    pub fn hash(&self) -> Result<Hash, Error> {
-        let buf = self.to_bytes()?;
-        let digest = crypto::generichash::hash(&buf, Some(32), None).unwrap();
-        Ok(digest.as_ref().try_into()?)
-    }
-    pub fn get_timestamp(&self) -> Option<u64> {
-        match &self.body {
-            PostBody::Text { timestamp, .. } => Some(*timestamp),
-            PostBody::Delete { timestamp, .. } => Some(*timestamp),
-            PostBody::Info { timestamp, .. } => Some(*timestamp),
-            PostBody::Topic { timestamp, .. } => Some(*timestamp),
-            PostBody::Join { timestamp, .. } => Some(*timestamp),
-            PostBody::Leave { timestamp, .. } => Some(*timestamp),
-            PostBody::Unrecognized { .. } => None,
-        }
-    }
-    pub fn get_channel<'a>(&'a self) -> Option<&'a Channel> {
-        match &self.body {
-            PostBody::Text { channel, .. } => Some(channel),
-            PostBody::Delete { .. } => None,
-            PostBody::Info { .. } => None,
-            PostBody::Topic { channel, .. } => Some(channel),
-            PostBody::Join { channel, .. } => Some(channel),
-            PostBody::Leave { channel, .. } => Some(channel),
-            PostBody::Unrecognized { .. } => None,
-        }
-    }
-}
-
-impl CountBytes for Post {
-    fn count_bytes(&self) -> usize {
-        let post_type = self.post_type();
-        let header_size = 32 + 64 + 32;
-        let body_size = varint::length(post_type)
-            + match &self.body {
-                PostBody::Text {
-                    channel,
-                    timestamp,
-                    text,
-                } => {
-                    varint::length(channel.len() as u64)
-                        + channel.len()
-                        + varint::length(*timestamp)
-                        + varint::length(text.len() as u64)
-                        + text.len()
-                }
-                PostBody::Delete { timestamp, hash } => varint::length(*timestamp) + hash.len(),
-                PostBody::Info {
-                    timestamp,
-                    key,
-                    value,
-                } => {
-                    varint::length(*timestamp)
-                        + varint::length(key.len() as u64)
-                        + key.len()
-                        + varint::length(value.len() as u64)
-                        + value.len()
-                }
-                PostBody::Topic {
-                    channel,
-                    timestamp,
-                    topic,
-                } => {
-                    varint::length(channel.len() as u64)
-                        + channel.len()
-                        + varint::length(*timestamp)
-                        + varint::length(topic.len() as u64)
-                        + topic.len()
-                }
-                PostBody::Join { channel, timestamp } => {
-                    varint::length(channel.len() as u64)
-                        + channel.len()
-                        + varint::length(*timestamp)
-                }
-                PostBody::Leave { channel, timestamp } => {
-                    varint::length(channel.len() as u64)
-                        + channel.len()
-                        + varint::length(*timestamp)
-                }
-                PostBody::Unrecognized { .. } => 0,
-            };
-        header_size + body_size
-    }
-    fn count_from_bytes(_buf: &[u8]) -> Result<usize, Error> {
-        unimplemented![]
-    }
-}
-
-impl ToBytes for Post {
-    fn to_bytes(&self) -> Result<Vec<u8>, Error> {
-        let mut buf = vec![0; self.count_bytes()];
-        self.write_bytes(&mut buf)?;
-        Ok(buf)
-    }
-    fn write_bytes(&self, buf: &mut [u8]) -> Result<usize, Error> {
-        let mut offset = 0;
-        assert_eq![self.header.public_key.len(), 32];
-        assert_eq![self.header.signature.len(), 64];
-        assert_eq![self.header.link.len(), 32];
-        buf[offset..offset + 32].copy_from_slice(&self.header.public_key);
-        offset += self.header.public_key.len();
-        buf[offset..offset + 64].copy_from_slice(&self.header.signature);
-        offset += self.header.signature.len();
-        buf[offset..offset + 32].copy_from_slice(&self.header.link);
-        offset += self.header.link.len();
-        offset += varint::encode(self.post_type(), &mut buf[offset..])?;
-        match &self.body {
-            PostBody::Text {
-                channel,
-                timestamp,
-                text,
-            } => {
-                offset += varint::encode(channel.len() as u64, &mut buf[offset..])?;
-                buf[offset..offset + channel.len()].copy_from_slice(channel);
-                offset += channel.len();
-                offset += varint::encode(*timestamp, &mut buf[offset..])?;
-                offset += varint::encode(text.len() as u64, &mut buf[offset..])?;
-                buf[offset..offset + text.len()].copy_from_slice(text);
-                offset += text.len();
-            }
-            PostBody::Delete { timestamp, hash } => {
-                offset += varint::encode(*timestamp, &mut buf[offset..])?;
-                buf[offset..offset + hash.len()].copy_from_slice(hash);
-                offset += hash.len();
-            }
-            PostBody::Info {
-                timestamp,
-                key,
-                value,
-            } => {
-                offset += varint::encode(*timestamp, &mut buf[offset..])?;
-                offset += varint::encode(key.len() as u64, &mut buf[offset..])?;
-                buf[offset..offset + key.len()].copy_from_slice(key);
-                offset += key.len();
-                offset += varint::encode(value.len() as u64, &mut buf[offset..])?;
-                buf[offset..offset + value.len()].copy_from_slice(value);
-                offset += value.len();
-            }
-            PostBody::Topic {
-                channel,
-                timestamp,
-                topic,
-            } => {
-                offset += varint::encode(channel.len() as u64, &mut buf[offset..])?;
-                buf[offset..offset + channel.len()].copy_from_slice(channel);
-                offset += channel.len();
-                offset += varint::encode(*timestamp, &mut buf[offset..])?;
-                offset += varint::encode(topic.len() as u64, &mut buf[offset..])?;
-                buf[offset..offset + topic.len()].copy_from_slice(topic);
-                offset += topic.len();
-            }
-            PostBody::Join { channel, timestamp } => {
-                offset += varint::encode(channel.len() as u64, &mut buf[offset..])?;
-                buf[offset..offset + channel.len()].copy_from_slice(channel);
-                offset += channel.len();
-                offset += varint::encode(*timestamp, &mut buf[offset..])?;
-            }
-            PostBody::Leave { channel, timestamp } => {
-                offset += varint::encode(channel.len() as u64, &mut buf[offset..])?;
-                buf[offset..offset + channel.len()].copy_from_slice(channel);
-                offset += channel.len();
-                offset += varint::encode(*timestamp, &mut buf[offset..])?;
-            }
-            PostBody::Unrecognized { post_type } => {
-                return E::PostWriteUnrecognizedType {
-                    post_type: *post_type,
-                }
-                .raise();
-            }
-        }
-        Ok(offset)
-    }
-}
-
 impl FromBytes for Post {
     fn from_bytes(buf: &[u8]) -> Result<(usize, Self), Error> {
         let mut offset = 0;

--- a/cable/src/post.rs
+++ b/cable/src/post.rs
@@ -285,7 +285,7 @@ impl ToBytes for Post {
                 hashes,
             } => {
                 offset += varint::encode(*num_deletions, &mut buf[offset..])?;
-                buf[offset..offset + hashes.len()].copy_from_slice(&hashes);
+                buf[offset..offset + hashes.len()].copy_from_slice(hashes);
                 offset += hashes.len();
             }
             PostBody::Info { info } => {

--- a/cable/src/post.rs
+++ b/cable/src/post.rs
@@ -373,6 +373,7 @@ mod test {
     const DELETE_POST_HEX_BINARY: &str = "25b272a71555322d40efe449a7f99af8fd364b92d350f1664481b2da340a02d0affe77e3b3156cda7feea042269bb7e93f5031662c70610d37baa69132b4150c18d67cb2ac24fb0f9be0a6516e53ba2f3bbc5bd8e7a1bff64d9c78ce0c2e4205015049d089a650aa896cb25ec35258653be4df196b4a5e5b6db7ed024aaa89e1b301500315ed54965515babf6f16be3f96b04b29ecca813a343311dae483691c07ccf4e597fc63631c41384226b9b68d9f73ffaaf6eac54b71838687f48f112e30d6db689c2939fec6d47b00bafe6967aeff697cf4b5abca01b04ba1b31a7e3752454bfa";
     const INFO_POST_HEX_BINARY: &str = "25b272a71555322d40efe449a7f99af8fd364b92d350f1664481b2da340a02d0f70273779147a3b756407d5660ed2e8e2975abc5ab224fb152aa2bfb3dd331740a66e0718cd580bc94978c1c3cd4524ad8cb2f4cca80df481010c3ef834ac700015049d089a650aa896cb25ec35258653be4df196b4a5e5b6db7ed024aaa89e1b30250046e616d65066361626c6572";
     const TOPIC_POST_HEX_BINARY: &str = "25b272a71555322d40efe449a7f99af8fd364b92d350f1664481b2da340a02d0bf7578e781caee4ca708281645b291a2100c4f2138f0e0ac98bc2b4a414b4ba8dca08285751114b05f131421a1745b648c43b17b05392593237dfacc8dff5208015049d089a650aa896cb25ec35258653be4df196b4a5e5b6db7ed024aaa89e1b303500764656661756c743b696e74726f6475636520796f757273656c6620746f2074686520667269656e646c792063726f7764206f66206c696b656d696e64656420666f6c78";
+    const JOIN_POST_HEX_BINARY: &str = "25b272a71555322d40efe449a7f99af8fd364b92d350f1664481b2da340a02d064425f10fa34c1e14b6101491772d3c5f15f720a952dd56c27d5ad52f61f695130ce286de73e332612b36242339b61c9e12397f5dcc94c79055c7e1cb1dbfb08015049d089a650aa896cb25ec35258653be4df196b4a5e5b6db7ed024aaa89e1b304500764656661756c74";
 
     #[test]
     fn verify_post() {
@@ -515,25 +516,6 @@ mod test {
         assert_eq!(expected_bytes, post_bytes);
     }
 
-    /*
-        {
-      "name": "post/topic",
-      "type": "post",
-      "id": 3,
-      "binary": "25b272a71555322d40efe449a7f99af8fd364b92d350f1664481b2da340a02d0bf7578e781caee4ca708281645b291a2100c4f2138f0e0ac98bc2b4a414b4ba8dca08285751114b05f131421a1745b648c43b17b05392593237dfacc8dff5208015049d089a650aa896cb25ec35258653be4df196b4a5e5b6db7ed024aaa89e1b303500764656661756c743b696e74726f6475636520796f757273656c6620746f2074686520667269656e646c792063726f7764206f66206c696b656d696e64656420666f6c78",
-      "obj": {
-        "publicKey": "25b272a71555322d40efe449a7f99af8fd364b92d350f1664481b2da340a02d0",
-        "signature": "bf7578e781caee4ca708281645b291a2100c4f2138f0e0ac98bc2b4a414b4ba8dca08285751114b05f131421a1745b648c43b17b05392593237dfacc8dff5208",
-        "links": [
-          "5049d089a650aa896cb25ec35258653be4df196b4a5e5b6db7ed024aaa89e1b3"
-        ],
-        "postType": 3,
-        "channel": "default",
-        "timestamp": 80,
-        "topic": "introduce yourself to the friendly crowd of likeminded folx"
-      }
-    }
-        */
     #[test]
     fn topic_post_to_bytes() {
         /* HEADER FIELD VALUES */
@@ -565,6 +547,44 @@ mod test {
 
         // Test vector binary.
         let expected_bytes = <Vec<u8>>::from_hex(TOPIC_POST_HEX_BINARY).unwrap();
+
+        // Ensure the number of generated post bytes matches the number of
+        // expected bytes.
+        assert_eq!(expected_bytes.len(), post_bytes.len());
+
+        // Ensure the generated post bytes match the expected bytes.
+        assert_eq!(expected_bytes, post_bytes);
+    }
+
+    #[test]
+    fn join_post_to_bytes() {
+        /* HEADER FIELD VALUES */
+
+        let public_key = <[u8; 32]>::from_hex(PUBLIC_KEY).unwrap();
+        let signature = <[u8; 64]>::from_hex("64425f10fa34c1e14b6101491772d3c5f15f720a952dd56c27d5ad52f61f695130ce286de73e332612b36242339b61c9e12397f5dcc94c79055c7e1cb1dbfb08").unwrap();
+        let links = <Vec<u8>>::from_hex(POST_HASH).unwrap();
+        let post_type = 4;
+        let timestamp = 80;
+
+        // Construct a new post header.
+        let header = PostHeader::new(public_key, signature, links, post_type, timestamp);
+
+        /* BODY FIELD VALUES */
+
+        let channel = "default".to_string();
+
+        // Construct a new post body.
+        let body = PostBody::Join {
+            channel: channel.into(),
+        };
+
+        // Construct a new post.
+        let post = Post::new(header, body);
+        // Convert the post to bytes.
+        let post_bytes = post.to_bytes().unwrap();
+
+        // Test vector binary.
+        let expected_bytes = <Vec<u8>>::from_hex(JOIN_POST_HEX_BINARY).unwrap();
 
         // Ensure the number of generated post bytes matches the number of
         // expected bytes.

--- a/desert/src/varint.rs
+++ b/desert/src/varint.rs
@@ -1,5 +1,6 @@
 use crate::error::{DesertErrorKind, Error};
 
+/// Decode a varint into an unsigned 64 bit integer (includes offset in result).
 pub fn decode(buf: &[u8]) -> Result<(usize, u64), Error> {
     let mut value = 0u64;
     let mut m = 1u64;
@@ -19,6 +20,8 @@ pub fn decode(buf: &[u8]) -> Result<(usize, u64), Error> {
     Ok((offset, value))
 }
 
+/// Encode an unsigned 64 bit integer as a varint and write the bytes to the
+/// given buffer, returning the byte length of the value.
 pub fn encode(value: u64, buf: &mut [u8]) -> Result<usize, Error> {
     let len = length(value);
     if buf.len() < len {
@@ -35,7 +38,9 @@ pub fn encode(value: u64, buf: &mut [u8]) -> Result<usize, Error> {
     Ok(len)
 }
 
+/// Determine the length of an unsigned 64 bit integer.
 pub fn length(value: u64) -> usize {
+    // Determine the most-significant bit (MSB).
     let msb = (64 - value.leading_zeros()) as usize;
     (msb.max(1) + 6) / 7
 }


### PR DESCRIPTION
There's quite a lot included in this PR but it's all directed towards encoding `Post` types as bytes.

- Depend on workspace-local version of `desert`
- Fix backtrace in custom error implementation for `cable`
- Implement `ToBytes` for `Post`
- Implement `CountBytes` for `Post`
- Add `sign` method for `Post`
- Remove unnecessary length fields from `Post` header and body variants
  - I.e. `channel_len`, which can simply be calculated from `channel` instead 
- Add convenience constructor methods for `UserInfo` and `PostHeader`
- Add passing "happy path" tests for all post types
  - text
  - delete
  - info
  - topic
  - join
  - leave

Test vectors have been sourced from https://github.com/cabal-club/cable.js#examples