### PR TITLE
Implement `FromBytes` trait impl for `Post` and test all variants

### DIFF
--- a/cable/src/lib.rs
+++ b/cable/src/lib.rs
@@ -2,11 +2,15 @@ mod error;
 mod message;
 mod post;
 
+// TODO: Consider changing this to `String`.
+// Then use `.into_bytes()` where required.
 pub type Channel = Vec<u8>;
 pub type CircuitId = [u8; 4];
 pub type Hash = [u8; 32];
 pub type ReqId = [u8; 4];
+// TODO: Consider changing this to `String`.
 pub type Text = Vec<u8>;
+// TODO: Consider changing this to `String`.
 pub type Topic = Vec<u8>;
 
 #[derive(Clone, Debug)]

--- a/cable/src/post.rs
+++ b/cable/src/post.rs
@@ -861,4 +861,62 @@ mod test {
             panic!("Incorrect post type: expected text");
         }
     }
+
+    #[test]
+    fn bytes_to_delete_post() {
+        // Test vector binary.
+        let post_bytes = <Vec<u8>>::from_hex(DELETE_POST_HEX_BINARY).unwrap();
+
+        // Decode the byte slice to a `Post`.
+        let (_, post) = Post::from_bytes(&post_bytes).unwrap();
+
+        /* HEADER FIELD VALUES */
+
+        let expected_public_key = <[u8; 32]>::from_hex(PUBLIC_KEY).unwrap();
+        let expected_signature = <[u8; 64]>::from_hex("affe77e3b3156cda7feea042269bb7e93f5031662c70610d37baa69132b4150c18d67cb2ac24fb0f9be0a6516e53ba2f3bbc5bd8e7a1bff64d9c78ce0c2e4205").unwrap();
+        let expected_links = <Vec<u8>>::from_hex(POST_HASH).unwrap();
+        let expected_post_type = 1;
+        let expected_timestamp = 80;
+
+        let PostHeader {
+            public_key,
+            signature,
+            links,
+            post_type,
+            timestamp,
+        } = post.header;
+
+        // Ensure the post header fields are correct.
+        assert_eq!(public_key, expected_public_key);
+        assert_eq!(signature, expected_signature);
+        assert_eq!(links, expected_links);
+        assert_eq!(post_type, expected_post_type);
+        assert_eq!(timestamp, expected_timestamp);
+
+        /* BODY FIELD VALUES */
+
+        // Concatenate the hashes into a single `Vec<u8>`.
+        let mut expected_hashes =
+            <Vec<u8>>::from_hex("15ed54965515babf6f16be3f96b04b29ecca813a343311dae483691c07ccf4e5")
+                .unwrap();
+        expected_hashes.append(
+            &mut <Vec<u8>>::from_hex(
+                "97fc63631c41384226b9b68d9f73ffaaf6eac54b71838687f48f112e30d6db68",
+            )
+            .unwrap(),
+        );
+        expected_hashes.append(
+            &mut <Vec<u8>>::from_hex(
+                "9c2939fec6d47b00bafe6967aeff697cf4b5abca01b04ba1b31a7e3752454bfa",
+            )
+            .unwrap(),
+        );
+
+        // Ensure the post body fields are correct.
+        if let PostBody::Delete { hashes } = post.body {
+            assert_eq!(hashes, expected_hashes);
+        } else {
+            panic!("Incorrect post type: expected delete");
+        }
+    }
 }

--- a/cable/src/post.rs
+++ b/cable/src/post.rs
@@ -964,4 +964,51 @@ mod test {
             panic!("Incorrect post type: expected info");
         }
     }
+
+    #[test]
+    fn bytes_to_topic_post() {
+        // Test vector binary.
+        let post_bytes = <Vec<u8>>::from_hex(TOPIC_POST_HEX_BINARY).unwrap();
+
+        // Decode the byte slice to a `Post`.
+        let (_, post) = Post::from_bytes(&post_bytes).unwrap();
+
+        /* HEADER FIELD VALUES */
+
+        let expected_public_key = <[u8; 32]>::from_hex(PUBLIC_KEY).unwrap();
+        let expected_signature = <[u8; 64]>::from_hex("bf7578e781caee4ca708281645b291a2100c4f2138f0e0ac98bc2b4a414b4ba8dca08285751114b05f131421a1745b648c43b17b05392593237dfacc8dff5208").unwrap();
+        let expected_links = <Vec<u8>>::from_hex(POST_HASH).unwrap();
+        let expected_post_type = 3;
+        let expected_timestamp = 80;
+
+        let PostHeader {
+            public_key,
+            signature,
+            links,
+            post_type,
+            timestamp,
+        } = post.header;
+
+        // Ensure the post header fields are correct.
+        assert_eq!(public_key, expected_public_key);
+        assert_eq!(signature, expected_signature);
+        assert_eq!(links, expected_links);
+        assert_eq!(post_type, expected_post_type);
+        assert_eq!(timestamp, expected_timestamp);
+
+        /* BODY FIELD VALUES */
+
+        let expected_channel = "default".to_string().into_bytes();
+        let expected_topic = "introduce yourself to the friendly crowd of likeminded folx"
+            .to_string()
+            .into_bytes();
+
+        // Ensure the post body fields are correct.
+        if let PostBody::Topic { channel, topic } = post.body {
+            assert_eq!(channel, expected_channel);
+            assert_eq!(topic, expected_topic);
+        } else {
+            panic!("Incorrect post type: expected topic");
+        }
+    }
 }

--- a/cable/src/post.rs
+++ b/cable/src/post.rs
@@ -602,11 +602,10 @@ mod test {
 
         // Ensure the number of generated post bytes matches the number of
         // expected bytes.
-        // TODO: Flip the order of expected and result (result should come first).
-        assert_eq!(expected_bytes.len(), post_bytes.len());
+        assert_eq!(post_bytes.len(), expected_bytes.len());
 
         // Ensure the generated post bytes match the expected bytes.
-        assert_eq!(expected_bytes, post_bytes);
+        assert_eq!(post_bytes, expected_bytes);
     }
 
     #[test]
@@ -654,10 +653,10 @@ mod test {
 
         // Ensure the number of generated post bytes matches the number of
         // expected bytes.
-        assert_eq!(expected_bytes.len(), post_bytes.len());
+        assert_eq!(post_bytes.len(), expected_bytes.len());
 
         // Ensure the generated post bytes match the expected bytes.
-        assert_eq!(expected_bytes, post_bytes);
+        assert_eq!(post_bytes, expected_bytes);
     }
 
     #[test]
@@ -694,10 +693,10 @@ mod test {
 
         // Ensure the number of generated post bytes matches the number of
         // expected bytes.
-        assert_eq!(expected_bytes.len(), post_bytes.len());
+        assert_eq!(post_bytes.len(), expected_bytes.len());
 
         // Ensure the generated post bytes match the expected bytes.
-        assert_eq!(expected_bytes, post_bytes);
+        assert_eq!(post_bytes, expected_bytes);
     }
 
     #[test]
@@ -734,10 +733,10 @@ mod test {
 
         // Ensure the number of generated post bytes matches the number of
         // expected bytes.
-        assert_eq!(expected_bytes.len(), post_bytes.len());
+        assert_eq!(post_bytes.len(), expected_bytes.len());
 
         // Ensure the generated post bytes match the expected bytes.
-        assert_eq!(expected_bytes, post_bytes);
+        assert_eq!(post_bytes, expected_bytes);
     }
 
     #[test]
@@ -772,10 +771,10 @@ mod test {
 
         // Ensure the number of generated post bytes matches the number of
         // expected bytes.
-        assert_eq!(expected_bytes.len(), post_bytes.len());
+        assert_eq!(post_bytes.len(), expected_bytes.len());
 
         // Ensure the generated post bytes match the expected bytes.
-        assert_eq!(expected_bytes, post_bytes);
+        assert_eq!(post_bytes, expected_bytes);
     }
 
     #[test]
@@ -810,10 +809,10 @@ mod test {
 
         // Ensure the number of generated post bytes matches the number of
         // expected bytes.
-        assert_eq!(expected_bytes.len(), post_bytes.len());
+        assert_eq!(post_bytes.len(), expected_bytes.len());
 
         // Ensure the generated post bytes match the expected bytes.
-        assert_eq!(expected_bytes, post_bytes);
+        assert_eq!(post_bytes, expected_bytes);
     }
 
     /* BYTES TO POST TESTS */

--- a/cable/src/post.rs
+++ b/cable/src/post.rs
@@ -21,7 +21,7 @@ use crate::{
     Channel, Hash, Text, Topic,
 };
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 /// Information self-published by a user.
 pub struct UserInfo {
     pub key: Vec<u8>,
@@ -917,6 +917,51 @@ mod test {
             assert_eq!(hashes, expected_hashes);
         } else {
             panic!("Incorrect post type: expected delete");
+        }
+    }
+
+    #[test]
+    fn bytes_to_info_post() {
+        // Test vector binary.
+        let post_bytes = <Vec<u8>>::from_hex(INFO_POST_HEX_BINARY).unwrap();
+
+        // Decode the byte slice to a `Post`.
+        let (_, post) = Post::from_bytes(&post_bytes).unwrap();
+
+        /* HEADER FIELD VALUES */
+
+        let expected_public_key = <[u8; 32]>::from_hex(PUBLIC_KEY).unwrap();
+        let expected_signature = <[u8; 64]>::from_hex("f70273779147a3b756407d5660ed2e8e2975abc5ab224fb152aa2bfb3dd331740a66e0718cd580bc94978c1c3cd4524ad8cb2f4cca80df481010c3ef834ac700").unwrap();
+        let expected_links = <Vec<u8>>::from_hex(POST_HASH).unwrap();
+        let expected_post_type = 2;
+        let expected_timestamp = 80;
+
+        let PostHeader {
+            public_key,
+            signature,
+            links,
+            post_type,
+            timestamp,
+        } = post.header;
+
+        // Ensure the post header fields are correct.
+        assert_eq!(public_key, expected_public_key);
+        assert_eq!(signature, expected_signature);
+        assert_eq!(links, expected_links);
+        assert_eq!(post_type, expected_post_type);
+        assert_eq!(timestamp, expected_timestamp);
+
+        /* BODY FIELD VALUES */
+
+        let key = "name".to_string();
+        let val = "cabler".to_string();
+        let expected_info = vec![UserInfo::new(key, val)];
+
+        // Ensure the post body fields are correct.
+        if let PostBody::Info { info } = post.body {
+            assert_eq!(info, expected_info);
+        } else {
+            panic!("Incorrect post type: expected info");
         }
     }
 }

--- a/cable/src/post.rs
+++ b/cable/src/post.rs
@@ -1011,4 +1011,90 @@ mod test {
             panic!("Incorrect post type: expected topic");
         }
     }
+
+    #[test]
+    fn bytes_to_join_post() {
+        // Test vector binary.
+        let post_bytes = <Vec<u8>>::from_hex(JOIN_POST_HEX_BINARY).unwrap();
+
+        // Decode the byte slice to a `Post`.
+        let (_, post) = Post::from_bytes(&post_bytes).unwrap();
+
+        /* HEADER FIELD VALUES */
+
+        let expected_public_key = <[u8; 32]>::from_hex(PUBLIC_KEY).unwrap();
+        let expected_signature = <[u8; 64]>::from_hex("64425f10fa34c1e14b6101491772d3c5f15f720a952dd56c27d5ad52f61f695130ce286de73e332612b36242339b61c9e12397f5dcc94c79055c7e1cb1dbfb08").unwrap();
+        let expected_links = <Vec<u8>>::from_hex(POST_HASH).unwrap();
+        let expected_post_type = 4;
+        let expected_timestamp = 80;
+
+        let PostHeader {
+            public_key,
+            signature,
+            links,
+            post_type,
+            timestamp,
+        } = post.header;
+
+        // Ensure the post header fields are correct.
+        assert_eq!(public_key, expected_public_key);
+        assert_eq!(signature, expected_signature);
+        assert_eq!(links, expected_links);
+        assert_eq!(post_type, expected_post_type);
+        assert_eq!(timestamp, expected_timestamp);
+
+        /* BODY FIELD VALUES */
+
+        let expected_channel = "default".to_string().into_bytes();
+
+        // Ensure the post body fields are correct.
+        if let PostBody::Join { channel } = post.body {
+            assert_eq!(channel, expected_channel);
+        } else {
+            panic!("Incorrect post type: expected join");
+        }
+    }
+
+    #[test]
+    fn bytes_to_leave_post() {
+        // Test vector binary.
+        let post_bytes = <Vec<u8>>::from_hex(LEAVE_POST_HEX_BINARY).unwrap();
+
+        // Decode the byte slice to a `Post`.
+        let (_, post) = Post::from_bytes(&post_bytes).unwrap();
+
+        /* HEADER FIELD VALUES */
+
+        let expected_public_key = <[u8; 32]>::from_hex(PUBLIC_KEY).unwrap();
+        let expected_signature = <[u8; 64]>::from_hex("abb083ecdca569f064564942ddf1944fbf550dc27ea36a7074be798d753cb029703de77b1a9532b6ca2ec5706e297dce073d6e508eeb425c32df8431e4677805").unwrap();
+        let expected_links = <Vec<u8>>::from_hex(POST_HASH).unwrap();
+        let expected_post_type = 5;
+        let expected_timestamp = 80;
+
+        let PostHeader {
+            public_key,
+            signature,
+            links,
+            post_type,
+            timestamp,
+        } = post.header;
+
+        // Ensure the post header fields are correct.
+        assert_eq!(public_key, expected_public_key);
+        assert_eq!(signature, expected_signature);
+        assert_eq!(links, expected_links);
+        assert_eq!(post_type, expected_post_type);
+        assert_eq!(timestamp, expected_timestamp);
+
+        /* BODY FIELD VALUES */
+
+        let expected_channel = "default".to_string().into_bytes();
+
+        // Ensure the post body fields are correct.
+        if let PostBody::Leave { channel } = post.body {
+            assert_eq!(channel, expected_channel);
+        } else {
+            panic!("Incorrect post type: expected leave");
+        }
+    }
 }


### PR DESCRIPTION
- Implement `FromBytes` for `Post`
- Ensure spec conformity by adding `key_len == 0` to indicate that no more key-value pairs remain
  - Only pertains to `post/info`
- Add passing "happy path" tests for all post types
  - text
  - delete
  - info (currently fails due to test vector which is not fully spec-conforming)
  - topic
  - join
  - leave
- Also left a `TODO` note about possibly changing `Channel` and `Text` from `Vec<u8>` to `String`
  - This should make things a little more ergonomic for client devs to construct `Post` types