### PR TITLE
Use `String` (UTF-8) instead of `Vec<u8>`

### DIFF
--- a/cable/src/lib.rs
+++ b/cable/src/lib.rs
@@ -2,12 +2,13 @@ mod error;
 mod message;
 mod post;
 
+// TODO: Add a validation function to check length.
 pub type Channel = String;
 pub type CircuitId = [u8; 4];
 pub type Hash = [u8; 32];
 pub type ReqId = [u8; 4];
-// TODO: Consider changing this to `String`.
-pub type Text = Vec<u8>;
+pub type Text = String;
+// TODO: Add a validation function to check length.
 pub type Topic = String;
 
 #[derive(Clone, Debug)]

--- a/cable/src/lib.rs
+++ b/cable/src/lib.rs
@@ -2,16 +2,13 @@ mod error;
 mod message;
 mod post;
 
-// TODO: Consider changing this to `String`.
-// Then use `.into_bytes()` where required.
 pub type Channel = String;
 pub type CircuitId = [u8; 4];
 pub type Hash = [u8; 32];
 pub type ReqId = [u8; 4];
 // TODO: Consider changing this to `String`.
 pub type Text = Vec<u8>;
-// TODO: Consider changing this to `String`.
-pub type Topic = Vec<u8>;
+pub type Topic = String;
 
 #[derive(Clone, Debug)]
 /// The length and data of an encoded channel name.

--- a/cable/src/lib.rs
+++ b/cable/src/lib.rs
@@ -4,7 +4,7 @@ mod post;
 
 // TODO: Consider changing this to `String`.
 // Then use `.into_bytes()` where required.
-pub type Channel = Vec<u8>;
+pub type Channel = String;
 pub type CircuitId = [u8; 4];
 pub type Hash = [u8; 32];
 pub type ReqId = [u8; 4];
@@ -19,7 +19,7 @@ pub struct EncodedChannel {
     /// The length of the channel name in bytes.
     pub channel_len: Vec<u8>, // varint
     /// The channel name data.
-    pub channel: Channel,
+    pub channel: Vec<u8>,
 }
 
 /*

--- a/cable/src/post.rs
+++ b/cable/src/post.rs
@@ -297,7 +297,7 @@ impl ToBytes for Post {
                 offset += channel.len();
 
                 offset += varint::encode(text.len() as u64, &mut buf[offset..])?;
-                buf[offset..offset + text.len()].copy_from_slice(text);
+                buf[offset..offset + text.len()].copy_from_slice(text.as_bytes());
                 offset += text.len();
             }
             PostBody::Delete { hashes } => {
@@ -416,7 +416,7 @@ impl FromBytes for Post {
                 offset += s;
 
                 // Read the text bytes and increment the offset.
-                let text = buf[offset..offset + text_len as usize].to_vec();
+                let text = String::from_utf8(buf[offset..offset + text_len as usize].to_vec())?;
                 offset += text_len as usize;
 
                 PostBody::Text { channel, text }
@@ -693,7 +693,7 @@ mod test {
         /* BODY FIELD VALUES */
 
         let channel = "default".to_string();
-        let text: Vec<u8> = "h€llo world".to_string().into();
+        let text = "h€llo world".to_string();
 
         // Construct a new post body.
         let body = PostBody::Text { channel, text };
@@ -725,7 +725,7 @@ mod test {
         /* BODY FIELD VALUES */
 
         let channel = "default".to_string();
-        let text: Vec<u8> = "h€llo world".to_string().into();
+        let text = "h€llo world".to_string();
 
         // Construct a new post body.
         let body = PostBody::Text { channel, text };
@@ -995,7 +995,7 @@ mod test {
         /* BODY FIELD VALUES */
 
         let expected_channel = "default".to_string();
-        let expected_text: Vec<u8> = "h€llo world".to_string().into();
+        let expected_text = "h€llo world".to_string();
 
         // Ensure the post body fields are correct.
         if let PostBody::Text { channel, text } = post.body {

--- a/cable/src/post.rs
+++ b/cable/src/post.rs
@@ -324,7 +324,7 @@ impl ToBytes for Post {
                 buf[offset..offset + channel.len()].copy_from_slice(channel.as_bytes());
                 offset += channel.len();
                 offset += varint::encode(topic.len() as u64, &mut buf[offset..])?;
-                buf[offset..offset + topic.len()].copy_from_slice(topic);
+                buf[offset..offset + topic.len()].copy_from_slice(topic.as_bytes());
                 offset += topic.len();
             }
             PostBody::Join { channel } => {
@@ -490,7 +490,7 @@ impl FromBytes for Post {
                 offset += s;
 
                 // Read the topic bytes and increment the offset.
-                let topic = buf[offset..offset + topic_len as usize].to_vec();
+                let topic = String::from_utf8(buf[offset..offset + topic_len as usize].to_vec())?;
                 offset += topic_len as usize;
 
                 PostBody::Topic { channel, topic }
@@ -1143,9 +1143,8 @@ mod test {
         /* BODY FIELD VALUES */
 
         let expected_channel = "default".to_string();
-        let expected_topic = "introduce yourself to the friendly crowd of likeminded folx"
-            .to_string()
-            .into_bytes();
+        let expected_topic =
+            "introduce yourself to the friendly crowd of likeminded folx".to_string();
 
         // Ensure the post body fields are correct.
         if let PostBody::Topic { channel, topic } = post.body {

--- a/cable/src/post.rs
+++ b/cable/src/post.rs
@@ -626,7 +626,7 @@ mod test {
 
         /* BODY FIELD VALUES */
 
-        let channel = "default".to_string().into_bytes();
+        let channel = "default".to_string();
 
         // Construct a new post body.
         let body = PostBody::Join {
@@ -663,7 +663,7 @@ mod test {
         /* BODY FIELD VALUES */
 
         let body = PostBody::Leave {
-            channel: "default".to_string().into_bytes(),
+            channel: "default".to_string(),
         };
 
         let post = Post { header, body };
@@ -692,7 +692,7 @@ mod test {
 
         /* BODY FIELD VALUES */
 
-        let channel: Vec<u8> = "default".to_string().into();
+        let channel = "default".to_string();
         let text: Vec<u8> = "h€llo world".to_string().into();
 
         // Construct a new post body.
@@ -724,7 +724,7 @@ mod test {
 
         /* BODY FIELD VALUES */
 
-        let channel: Vec<u8> = "default".to_string().into();
+        let channel = "default".to_string();
         let text: Vec<u8> = "h€llo world".to_string().into();
 
         // Construct a new post body.
@@ -994,7 +994,7 @@ mod test {
 
         /* BODY FIELD VALUES */
 
-        let expected_channel: Vec<u8> = "default".to_string().into();
+        let expected_channel = "default".to_string();
         let expected_text: Vec<u8> = "h€llo world".to_string().into();
 
         // Ensure the post body fields are correct.
@@ -1142,7 +1142,7 @@ mod test {
 
         /* BODY FIELD VALUES */
 
-        let expected_channel = "default".to_string().into_bytes();
+        let expected_channel = "default".to_string();
         let expected_topic = "introduce yourself to the friendly crowd of likeminded folx"
             .to_string()
             .into_bytes();
@@ -1191,7 +1191,7 @@ mod test {
 
         /* BODY FIELD VALUES */
 
-        let expected_channel = "default".to_string().into_bytes();
+        let expected_channel = "default".to_string();
 
         // Ensure the post body fields are correct.
         if let PostBody::Join { channel } = post.body {
@@ -1236,7 +1236,7 @@ mod test {
 
         /* BODY FIELD VALUES */
 
-        let expected_channel = "default".to_string().into_bytes();
+        let expected_channel = "default".to_string();
 
         // Ensure the post body fields are correct.
         if let PostBody::Leave { channel } = post.body {

--- a/cable/src/post.rs
+++ b/cable/src/post.rs
@@ -15,17 +15,16 @@ use crate::{
     Channel, Hash, Text, Topic,
 };
 
-// TODO: Consider changing `key` and `val` to `String`.
 #[derive(Clone, Debug, PartialEq)]
 /// Information self-published by a user.
 pub struct UserInfo {
-    pub key: Vec<u8>,
-    pub val: Vec<u8>,
+    pub key: String,
+    pub val: String,
 }
 
 impl UserInfo {
     /// Convenience method to construct `UserInfo`.
-    pub fn new<T: Into<Vec<u8>>, U: Into<Vec<u8>>>(key: T, val: U) -> Self {
+    pub fn new<T: Into<String>, U: Into<String>>(key: T, val: U) -> Self {
         UserInfo {
             key: key.into(),
             val: val.into(),
@@ -308,10 +307,10 @@ impl ToBytes for Post {
             PostBody::Info { info } => {
                 for UserInfo { key, val } in info {
                     offset += varint::encode(key.len() as u64, &mut buf[offset..])?;
-                    buf[offset..offset + key.len()].copy_from_slice(key);
+                    buf[offset..offset + key.len()].copy_from_slice(key.as_bytes());
                     offset += key.len();
                     offset += varint::encode(val.len() as u64, &mut buf[offset..])?;
-                    buf[offset..offset + val.len()].copy_from_slice(val);
+                    buf[offset..offset + val.len()].copy_from_slice(val.as_bytes());
                     offset += val.len();
                 }
 
@@ -456,7 +455,7 @@ impl FromBytes for Post {
                     }
 
                     // Read the key bytes and increment the offset.
-                    let key = buf[offset..offset + key_len as usize].to_vec();
+                    let key = String::from_utf8(buf[offset..offset + key_len as usize].to_vec())?;
                     offset += key_len as usize;
 
                     // Read the val length byte and increment the offset.
@@ -464,7 +463,7 @@ impl FromBytes for Post {
                     offset += s;
 
                     // Read the val bytes and increment the offset.
-                    let val = buf[offset..offset + val_len as usize].to_vec();
+                    let val = String::from_utf8(buf[offset..offset + val_len as usize].to_vec())?;
                     offset += val_len as usize;
 
                     let key_val = UserInfo::new(key, val);
@@ -810,8 +809,8 @@ mod test {
 
         /* BODY FIELD VALUES */
 
-        let key = "name".to_string();
-        let val = "cabler".to_string();
+        let key = "name";
+        let val = "cabler";
         let user_info = UserInfo::new(key, val);
 
         // Construct a new post body.
@@ -1095,8 +1094,8 @@ mod test {
 
         /* BODY FIELD VALUES */
 
-        let key = "name".to_string();
-        let val = "cabler".to_string();
+        let key = "name";
+        let val = "cabler";
         let expected_info = vec![UserInfo::new(key, val)];
 
         // Ensure the post body fields are correct.

--- a/cable/src/post.rs
+++ b/cable/src/post.rs
@@ -292,7 +292,8 @@ impl ToBytes for Post {
         match &self.body {
             PostBody::Text { channel, text } => {
                 offset += varint::encode(channel.len() as u64, &mut buf[offset..])?;
-                buf[offset..offset + channel.len()].copy_from_slice(channel);
+                //buf[offset..offset + channel.len()].copy_from_slice(&channel.into_bytes());
+                buf[offset..offset + channel.len()].copy_from_slice(channel.as_bytes());
                 offset += channel.len();
 
                 offset += varint::encode(text.len() as u64, &mut buf[offset..])?;
@@ -320,7 +321,7 @@ impl ToBytes for Post {
             }
             PostBody::Topic { channel, topic } => {
                 offset += varint::encode(channel.len() as u64, &mut buf[offset..])?;
-                buf[offset..offset + channel.len()].copy_from_slice(channel);
+                buf[offset..offset + channel.len()].copy_from_slice(channel.as_bytes());
                 offset += channel.len();
                 offset += varint::encode(topic.len() as u64, &mut buf[offset..])?;
                 buf[offset..offset + topic.len()].copy_from_slice(topic);
@@ -328,12 +329,12 @@ impl ToBytes for Post {
             }
             PostBody::Join { channel } => {
                 offset += varint::encode(channel.len() as u64, &mut buf[offset..])?;
-                buf[offset..offset + channel.len()].copy_from_slice(channel);
+                buf[offset..offset + channel.len()].copy_from_slice(channel.as_bytes());
                 offset += channel.len();
             }
             PostBody::Leave { channel } => {
                 offset += varint::encode(channel.len() as u64, &mut buf[offset..])?;
-                buf[offset..offset + channel.len()].copy_from_slice(channel);
+                buf[offset..offset + channel.len()].copy_from_slice(channel.as_bytes());
                 offset += channel.len();
             }
             PostBody::Unrecognized { post_type } => {
@@ -406,7 +407,8 @@ impl FromBytes for Post {
                 offset += s;
 
                 // Read the channel bytes and increment the offset.
-                let channel = buf[offset..offset + channel_len as usize].to_vec();
+                let channel =
+                    String::from_utf8(buf[offset..offset + channel_len as usize].to_vec())?;
                 offset += channel_len as usize;
 
                 // Read the text length byte and increment the offset.
@@ -479,7 +481,8 @@ impl FromBytes for Post {
                 offset += s;
 
                 // Read the channel bytes and increment the offset.
-                let channel = buf[offset..offset + channel_len as usize].to_vec();
+                let channel =
+                    String::from_utf8(buf[offset..offset + channel_len as usize].to_vec())?;
                 offset += channel_len as usize;
 
                 // Read the topic length byte and increment the offset.
@@ -499,7 +502,8 @@ impl FromBytes for Post {
                 offset += s;
 
                 // Read the channel bytes and increment the offset.
-                let channel = buf[offset..offset + channel_len as usize].to_vec();
+                let channel =
+                    String::from_utf8(buf[offset..offset + channel_len as usize].to_vec())?;
                 offset += s;
 
                 PostBody::Join { channel }
@@ -511,7 +515,8 @@ impl FromBytes for Post {
                 offset += s;
 
                 // Read the channel bytes and increment the offset.
-                let channel = buf[offset..offset + channel_len as usize].to_vec();
+                let channel =
+                    String::from_utf8(buf[offset..offset + channel_len as usize].to_vec())?;
                 offset += s;
 
                 PostBody::Leave { channel }


### PR DESCRIPTION
I was erroneously using `Vec<u8>` for a number of types. This PR changes those to `String` (UTF-8) and updates the tests accordingly.

- `Channel`
- `Text`
- `Topic`
- `UserInfo`