### PR TITLE
Update `Message` types and implement `CountBytes` for `Message`

### DIFF
--- a/cable/src/lib.rs
+++ b/cable/src/lib.rs
@@ -11,14 +11,8 @@ pub type Text = String;
 // TODO: Add a validation function to check length.
 pub type Topic = String;
 
-#[derive(Clone, Debug)]
-/// The length and data of an encoded channel name.
-pub struct EncodedChannel {
-    /// The length of the channel name in bytes.
-    pub channel_len: Vec<u8>, // varint
-    /// The channel name data.
-    pub channel: Vec<u8>,
-}
+/// The data of an encoded channel name.
+pub type EncodedChannel = Vec<u8>;
 
 /*
 #![feature(backtrace, async_closure, drain_filter)]

--- a/cable/src/message.rs
+++ b/cable/src/message.rs
@@ -20,9 +20,9 @@ pub struct Message {
 /// The header of a request or response message.
 pub struct MessageHeader {
     /// Number of bytes in the rest of the message, not including the `msg_len` field.
-    pub msg_len: Vec<u8>, // varint
+    pub msg_len: u64, // varint
     /// Type identifier for the message (controls which fields follow the header).
-    pub msg_type: Vec<u8>, // varint
+    pub msg_type: u64, // varint
     /// ID of a circuit for an established path; `[0,0,0,0]` for no circuit (current default).
     pub circuit_id: CircuitId,
     /// Unique ID of this request (randomly-assigned).
@@ -34,7 +34,7 @@ pub struct MessageHeader {
 pub enum MessageBody {
     Request {
         /// Number of network hops remaining (must be between 0 and 16).
-        ttl: Vec<u8>, // varint
+        ttl: u8, // varint
         body: RequestBody,
     },
     Response {
@@ -72,16 +72,16 @@ pub enum RequestBody {
         /// Beginning of the time range (in milliseconds since the UNIX Epoch).
         ///
         /// This represents the age of the oldest post the requester is interested in.
-        time_start: Vec<u8>, // varint
+        time_start: u64, // varint
         /// End of the time range (in milliseconds since the UNIX Epoch).
         ///
         /// This represents the age of the newest post the requester is interested in.
         ///
         /// A value of `0` is a keep-alive request; the responder should continue
         /// to send chat messages as they learn of them in the future.
-        time_end: Vec<u8>, // varint
+        time_end: u64, // varint
         /// Maximum numbers of hashes to return.
-        limit: Vec<u8>, // varint
+        limit: u64, // varint
     },
     /// Request posts that describe the current state of a channel and it's members,
     /// and optionally subscribe to future state changes.
@@ -104,7 +104,7 @@ pub enum RequestBody {
         /// held open indefinitely on both the requester and responder side until
         /// either a Cancel Request is issued by the requester or the responder
         /// elects to end the request by sending a Hash Response with hash_count = 0.
-        future: Vec<u8>, // varint
+        future: bool, // varint
     },
     /// Request a list of known channels from peers.
     ///
@@ -114,12 +114,12 @@ pub enum RequestBody {
     /// Message type (`msg_type`) is `6`.
     ChannelList {
         /// Number of channel names to skip (`0` to skip none).
-        offset: Vec<u8>, // varint
+        offset: u64, // varint
         /// Maximum number of channel names to return.
         ///
         /// If set to `0`, the responder must respond with all known channels
         /// (after skipping the first `offset` entries).
-        limit: Vec<u8>, // varint
+        limit: u64, // varint
     },
 }
 

--- a/cable/src/message.rs
+++ b/cable/src/message.rs
@@ -48,8 +48,6 @@ pub enum RequestBody {
     ///
     /// Message type (`msg_type`) is `2`.
     Post {
-        /// Number of hashes being requested.
-        hash_count: Vec<u8>, // varint
         /// Hashes being requested (concatenated together).
         hashes: Vec<Hash>,
     },
@@ -65,8 +63,6 @@ pub enum RequestBody {
     ///
     /// Message type (`msg_type`) is `4`.
     ChannelTimeRange {
-        /// Length of the channel's name in bytes.
-        channel_len: Vec<u8>, // varint
         /// Channel name (UTF-8).
         channel: Channel,
         /// Beginning of the time range (in milliseconds since the UNIX Epoch).
@@ -88,8 +84,6 @@ pub enum RequestBody {
     ///
     /// Message type (`msg_type`) is `5`.
     ChannelState {
-        /// Length of the channel's name in bytes.
-        channel_len: Vec<u8>, // varint
         /// Channel name (UTF-8).
         channel: Channel,
         /// Whether to include live/future state hashes.
@@ -129,8 +123,6 @@ pub enum ResponseBody {
     ///
     /// Message type (`msg_type`) is `0`.
     Hash {
-        /// Number of hashes in the response.
-        hash_count: Vec<u8>, // varint
         /// Hashes being sent in response (concatenated together).
         hashes: Vec<Hash>,
     },

--- a/cable/src/post.rs
+++ b/cable/src/post.rs
@@ -32,14 +32,8 @@ impl UserInfo {
     }
 }
 
-#[derive(Clone, Debug)]
-/// The length and data of an encoded post.
-pub struct EncodedPost {
-    /// The length of the post in bytes.
-    pub post_len: u64,
-    /// The post data.
-    pub post_data: Vec<u8>,
-}
+/// The data of an encoded post.
+pub type EncodedPost = Vec<u8>;
 
 #[derive(Clone, Debug)]
 pub struct Post {
@@ -529,6 +523,7 @@ impl FromBytes for Post {
 }
 
 impl CountBytes for Post {
+    /// Calculate the total number of bytes comprising the encoded post.
     fn count_bytes(&self) -> usize {
         let post_type = self.post_type();
 


### PR DESCRIPTION
This PR improves the representation of the `Message` types and begins implementing the required methods such as `message_type()`, `count_bytes()` and `count_from_bytes()`.

- Replace `Vec<u8>` with `Vec<Hash>` where appropriate (links and hashes)
- Remove unnecessary length fields from `Message`
- Add `message_type()` method for `Message`
- Implement `CountBytes` for `Message`
- Clean-up some iterators