### PR TITLE
Implement `ToBytes` trait `impl` for `Message` and test all variants

### DIFF
--- a/cable/src/lib.rs
+++ b/cable/src/lib.rs
@@ -8,6 +8,8 @@ pub type CircuitId = [u8; 4];
 pub type Hash = [u8; 32];
 pub type ReqId = [u8; 4];
 pub type Text = String;
+/// Time in milliseconds since the UNIX Epoch.
+pub type Timestamp = u64;
 // TODO: Add a validation function to check length.
 pub type Topic = String;
 

--- a/cable/src/message.rs
+++ b/cable/src/message.rs
@@ -448,6 +448,61 @@ mod test {
     /* MESSAGE TO BYTES TESTS */
 
     #[test]
+    fn hash_request_to_bytes() -> Result<(), Error> {
+        /* HEADER FIELD VALUES */
+
+        let msg_len = 107;
+        let msg_type = 2;
+        let req_id = <[u8; 4]>::from_hex("04baaffb")?;
+
+        // Construct a new message header.
+        let header = MessageHeader::new(msg_type, CIRCUIT_ID, req_id);
+
+        /* BODY FIELD VALUES */
+
+        let ttl = 1;
+        // Create a vector of hashes.
+        let hashes: Vec<Hash> = vec![
+            <[u8; 32]>::from_hex(
+                "15ed54965515babf6f16be3f96b04b29ecca813a343311dae483691c07ccf4e5",
+            )?,
+            <[u8; 32]>::from_hex(
+                "97fc63631c41384226b9b68d9f73ffaaf6eac54b71838687f48f112e30d6db68",
+            )?,
+            <[u8; 32]>::from_hex(
+                "9c2939fec6d47b00bafe6967aeff697cf4b5abca01b04ba1b31a7e3752454bfa",
+            )?,
+        ];
+
+        // Construct a new request body.
+        let req_body = RequestBody::Post { hashes };
+        // Construct a new message body.
+        let body = MessageBody::Request {
+            ttl,
+            body: req_body,
+        };
+
+        // Construct a new message.
+        let msg = Message::new(header, body);
+        // Convert the message to bytes.
+        let msg_bytes = msg.to_bytes()?;
+
+        // Test vector binary.
+        let expected_bytes = <Vec<u8>>::from_hex(
+            "6b020000000004baaffb010315ed54965515babf6f16be3f96b04b29ecca813a343311dae483691c07ccf4e597fc63631c41384226b9b68d9f73ffaaf6eac54b71838687f48f112e30d6db689c2939fec6d47b00bafe6967aeff697cf4b5abca01b04ba1b31a7e3752454bfa",
+        )?;
+
+        // Ensure the number of generated message bytes matches the number of
+        // expected bytes.
+        assert_eq!(msg_bytes.len(), expected_bytes.len());
+
+        // Ensure the generated message bytes match the expected bytes.
+        assert_eq!(msg_bytes, expected_bytes);
+
+        Ok(())
+    }
+
+    #[test]
     fn cancel_request_to_bytes() -> Result<(), Error> {
         /* HEADER FIELD VALUES */
 

--- a/cable/src/message.rs
+++ b/cable/src/message.rs
@@ -539,6 +539,49 @@ mod test {
 
         Ok(())
     }
+
+    #[test]
+    fn channel_state_request_to_bytes() -> Result<(), Error> {
+        /* HEADER FIELD VALUES */
+
+        let msg_len = 19;
+        let msg_type = 5;
+        let req_id = <[u8; 4]>::from_hex("04baaffb")?;
+
+        // Construct a new message header.
+        let header = MessageHeader::new(msg_type, CIRCUIT_ID, req_id);
+
+        /* BODY FIELD VALUES */
+
+        let ttl = 1;
+        let channel = "default".to_string();
+        let future = 0;
+
+        // Construct a new request body.
+        let req_body = RequestBody::ChannelState { channel, future };
+        // Construct a new message body.
+        let body = MessageBody::Request {
+            body: req_body,
+            ttl,
+        };
+
+        // Construct a new message.
+        let msg = Message::new(header, body);
+        // Convert the message to bytes.
+        let msg_bytes = msg.to_bytes()?;
+
+        // Test vector binary.
+        let expected_bytes = <Vec<u8>>::from_hex("13050000000004baaffb010764656661756c7400")?;
+
+        // Ensure the number of generated message bytes matches the number of
+        // expected bytes.
+        assert_eq!(msg_bytes.len(), expected_bytes.len());
+
+        // Ensure the generated message bytes match the expected bytes.
+        assert_eq!(msg_bytes, expected_bytes);
+
+        Ok(())
+    }
 }
 
 /*

--- a/cable/src/message.rs
+++ b/cable/src/message.rs
@@ -582,6 +582,49 @@ mod test {
 
         Ok(())
     }
+
+    #[test]
+    fn channel_list_request_to_bytes() -> Result<(), Error> {
+        /* HEADER FIELD VALUES */
+
+        let msg_len = 12;
+        let msg_type = 6;
+        let req_id = <[u8; 4]>::from_hex("04baaffb")?;
+
+        // Construct a new message header.
+        let header = MessageHeader::new(msg_type, CIRCUIT_ID, req_id);
+
+        /* BODY FIELD VALUES */
+
+        let ttl = 1;
+        let skip = 0;
+        let limit = 20;
+
+        // Construct a new request body.
+        let req_body = RequestBody::ChannelList { skip, limit };
+        // Construct a new message body.
+        let body = MessageBody::Request {
+            body: req_body,
+            ttl,
+        };
+
+        // Construct a new message.
+        let msg = Message::new(header, body);
+        // Convert the message to bytes.
+        let msg_bytes = msg.to_bytes()?;
+
+        // Test vector binary.
+        let expected_bytes = <Vec<u8>>::from_hex("0c060000000004baaffb010014")?;
+
+        // Ensure the number of generated message bytes matches the number of
+        // expected bytes.
+        assert_eq!(msg_bytes.len(), expected_bytes.len());
+
+        // Ensure the generated message bytes match the expected bytes.
+        assert_eq!(msg_bytes, expected_bytes);
+
+        Ok(())
+    }
 }
 
 /*

--- a/cable/src/post.rs
+++ b/cable/src/post.rs
@@ -236,6 +236,7 @@ impl ToBytes for Post {
         let mut offset = 0;
 
         // Validate the length of the public key, signature and links fields.
+        // TODO: Rather raise an appropriate CableErrorKind here.
         assert_eq![self.header.public_key.len(), 32];
         assert_eq![self.header.signature.len(), 64];
         for link in &self.header.links {
@@ -292,7 +293,7 @@ impl ToBytes for Post {
             }
             PostBody::Delete { hashes } => {
                 offset += varint::encode(hashes.len() as u64, &mut buf[offset..])?;
-                for hash in hashes.iter() {
+                for hash in hashes {
                     if offset + hash.len() > buf.len() {
                         return CableErrorKind::DstTooSmall {
                             required: offset + hash.len(),
@@ -309,6 +310,7 @@ impl ToBytes for Post {
                     offset += varint::encode(key.len() as u64, &mut buf[offset..])?;
                     buf[offset..offset + key.len()].copy_from_slice(key.as_bytes());
                     offset += key.len();
+
                     offset += varint::encode(val.len() as u64, &mut buf[offset..])?;
                     buf[offset..offset + val.len()].copy_from_slice(val.as_bytes());
                     offset += val.len();


### PR DESCRIPTION
- Implement `ToBytes` for `Message`
- Add passing "happy path" tests for all message types
  - post request
  - cancel request
  - channel time range request
  - channel state request
  - channel list request
  - hash response
  - post response
  - channel list response
- Introduce a `Timestamp` custom type for use with all time fields