### PR TITLE
Add validators

### DIFF
--- a/cable/src/error.rs
+++ b/cable/src/error.rs
@@ -5,14 +5,14 @@ use std::backtrace::Backtrace;
 
 pub type Error = Box<dyn std::error::Error + Send + Sync>;
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub struct CableError {
     kind: CableErrorKind,
     #[cfg(feature = "nightly-features")]
     backtrace: Backtrace,
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum CableErrorKind {
     DstTooSmall { provided: usize, required: usize },
     MessageEmpty {},
@@ -27,6 +27,7 @@ pub enum CableErrorKind {
     NoneError { context: String },
     PostWriteUnrecognizedType { post_type: u64 },
     PostHashingFailed {},
+    UsernameLengthIncorrect { name: String, len: usize },
 }
 
 impl CableErrorKind {
@@ -58,7 +59,7 @@ impl std::fmt::Display for CableError {
             CableErrorKind::DstTooSmall { provided, required } => {
                 write![
                     f,
-                    "destination buffer too small. {} bytes required, {} provided",
+                    "destination buffer too small; {} bytes required, {} provided",
                     required, provided
                 ]
             }
@@ -91,6 +92,13 @@ impl std::fmt::Display for CableError {
             }
             CableErrorKind::PostWriteUnrecognizedType { post_type } => {
                 write![f, "cannot write unrecognized post_type={}", post_type]
+            }
+            CableErrorKind::UsernameLengthIncorrect { name, len } => {
+                write![
+                    f,
+                    "expected username between 1 and 32 codepoints; name `{}` is {} codepoints",
+                    name, len
+                ]
             }
         }
     }

--- a/cable/src/error.rs
+++ b/cable/src/error.rs
@@ -29,6 +29,7 @@ pub enum CableErrorKind {
     PostHashingFailed {},
     UsernameLengthIncorrect { name: String, len: usize },
     ChannelLengthIncorrect { channel: String, len: usize },
+    TopicLengthIncorrect { topic: String, len: usize },
 }
 
 impl CableErrorKind {
@@ -106,6 +107,13 @@ impl std::fmt::Display for CableError {
                     f,
                     "expected channel between 1 and 64 codepoints; channel `{}` is {} codepoints",
                     channel, len
+                ]
+            }
+            CableErrorKind::TopicLengthIncorrect { topic, len } => {
+                write![
+                    f,
+                    "expected topic between 0 and 512 codepoints; topic `{}` is {} codepoints",
+                    topic, len
                 ]
             }
         }

--- a/cable/src/error.rs
+++ b/cable/src/error.rs
@@ -28,6 +28,7 @@ pub enum CableErrorKind {
     PostWriteUnrecognizedType { post_type: u64 },
     PostHashingFailed {},
     UsernameLengthIncorrect { name: String, len: usize },
+    ChannelLengthIncorrect { channel: String, len: usize },
 }
 
 impl CableErrorKind {
@@ -98,6 +99,13 @@ impl std::fmt::Display for CableError {
                     f,
                     "expected username between 1 and 32 codepoints; name `{}` is {} codepoints",
                     name, len
+                ]
+            }
+            CableErrorKind::ChannelLengthIncorrect { channel, len } => {
+                write![
+                    f,
+                    "expected channel between 1 and 64 codepoints; channel `{}` is {} codepoints",
+                    channel, len
                 ]
             }
         }

--- a/cable/src/lib.rs
+++ b/cable/src/lib.rs
@@ -22,7 +22,6 @@ pub type ReqId = [u8; 4];
 pub type Text = String;
 /// Time in milliseconds since the UNIX Epoch.
 pub type Timestamp = u64;
-// TODO: Add a validation function to check length.
 /// The topic of a channel.
 pub type Topic = String;
 
@@ -69,34 +68,44 @@ impl UserInfo {
     }
 }
 
-/// Validation trait.
-trait Validator {
-    fn validate(&self) -> Result<(), Error>;
+/// Validate the length of a channel name (1 to 64 UTF-8 codepoints).
+fn validate_channel(channel: &String) -> Result<(), Error> {
+    // Determine the length of the given channel in UTF-8 codepoints.
+    let channel_len = channel.chars().count();
+    // The channel must be between 1 and 64 codepoints.
+    if !(1..=64).contains(&channel_len) {
+        return CableErrorKind::ChannelLengthIncorrect {
+            channel: channel.to_owned(),
+            len: channel_len,
+        }
+        .raise();
+    }
+
+    Ok(())
 }
 
-impl Validator for Channel {
-    fn validate(&self) -> Result<(), Error> {
-        // Determine the length of the given channel in UTF-8 codepoints.
-        let channel_len = self.chars().count();
-        // The channel must be between 1 and 64 codepoints.
-        if !(1..=64).contains(&channel_len) {
-            return CableErrorKind::ChannelLengthIncorrect {
-                channel: self.to_string(),
-                len: channel_len,
-            }
-            .raise();
+/// Validate the length of a topic name (1 to 512 UTF-8 codepoints).
+fn validate_topic(topic: &String) -> Result<(), Error> {
+    // Determine the length of the given channel topic in UTF-8 codepoints.
+    let topic_len = topic.chars().count();
+    // The topic must be between 0 and 512 codepoints.
+    if topic_len > 521 {
+        return CableErrorKind::TopicLengthIncorrect {
+            topic: topic.to_owned(),
+            len: topic_len,
         }
-
-        Ok(())
+        .raise();
     }
+
+    Ok(())
 }
 
 #[cfg(test)]
 mod test {
-    use super::{Channel, Error, UserInfo, Validator};
+    use super::{validate_channel, validate_topic, Channel, Error, Topic, UserInfo};
 
     #[test]
-    fn validate_username() -> Result<(), Error> {
+    fn validate_username_len() -> Result<(), Error> {
         // Test valid usernames.
         let _valid_name = UserInfo::name("glyph")?;
         let _valid_name_japanese = UserInfo::name("五十嵐大介")?;
@@ -125,12 +134,12 @@ mod test {
     }
 
     #[test]
-    fn validate_channel() -> Result<(), Error> {
+    fn validate_channel_len() -> Result<(), Error> {
         // Test valid channels.
         let valid_channel: Channel = String::from("home");
-        valid_channel.validate()?;
+        validate_channel(&valid_channel)?;
         let valid_channel_japanese: Channel = String::from("しろくまカフェ");
-        valid_channel_japanese.validate()?;
+        validate_channel(&valid_channel_japanese)?;
 
         // Test invalid channels.
 
@@ -138,7 +147,7 @@ mod test {
         let invalid_channel_long: Channel = String::from("The Tao can't be perceived. Smaller than an electron, it contains uncountable galaxies.");
 
         // Channel too short.
-        match invalid_channel_short.validate() {
+        match validate_channel(&invalid_channel_short) {
             Err(e) => assert_eq!(
                 e.to_string(),
                 "expected channel between 1 and 64 codepoints; channel `` is 0 codepoints"
@@ -147,11 +156,35 @@ mod test {
         }
 
         // Channel too long.
-        match invalid_channel_long.validate() {
+        match validate_channel(&invalid_channel_long) {
             Err(e) => assert_eq!(
                 e.to_string(),
                 "expected channel between 1 and 64 codepoints; channel `The Tao can't be perceived. Smaller than an electron, it contains uncountable galaxies.` is 87 codepoints"
             ),
+            _ => panic!(),
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn validate_topic_len() -> Result<(), Error> {
+        // Test valid topics.
+        let valid_topic: Topic = String::from("");
+        validate_topic(&valid_topic)?;
+        let valid_topic_long: Topic = String::from("The great Tao flows everywhere. All things are born from it, yet it doesn't create them. It pours itself into its work, yet it makes no claim. It nourishes infinite worlds, yet it doesn't hold on to them. Since it is merged with all things and hidden in their hearts, it can be called humble.");
+        validate_topic(&valid_topic_long)?;
+
+        // Test invalid channels.
+
+        let invalid_topic_long: Topic = String::from("Bees are winged insects closely related to wasps and ants, known for their roles in pollination and, in the case of the best-known bee species, the western honey bee, for producing honey. Bees are a monophyletic lineage within the superfamily Apoidea. They are presently considered a clade, called Anthophila. There are over 16,000 known species of bees in seven recognized biological families. Some species – including honey bees, bumblebees, and stingless bees – live socially in colonies while most species (>90%) – including mason bees, carpenter bees, leafcutter bees, and sweat bees – are solitary.");
+
+        // Topic too long.
+        match validate_topic(&invalid_topic_long) {
+            Err(e) => assert_eq!(
+                e.to_string(),
+                "expected topic between 0 and 512 codepoints; topic `Bees are winged insects closely related to wasps and ants, known for their roles in pollination and, in the case of the best-known bee species, the western honey bee, for producing honey. Bees are a monophyletic lineage within the superfamily Apoidea. They are presently considered a clade, called Anthophila. There are over 16,000 known species of bees in seven recognized biological families. Some species – including honey bees, bumblebees, and stingless bees – live socially in colonies while most species (>90%) – including mason bees, carpenter bees, leafcutter bees, and sweat bees – are solitary.` is 604 codepoints"
+                ),
             _ => panic!(),
         }
 

--- a/cable/src/lib.rs
+++ b/cable/src/lib.rs
@@ -4,6 +4,8 @@ pub mod error;
 pub mod message;
 pub mod post;
 
+use crate::error::{CableErrorKind, Error};
+
 /// The name of a channel.
 // TODO: Add a validation function to check length.
 pub type Channel = String;
@@ -26,9 +28,78 @@ pub type Timestamp = u64;
 pub type Topic = String;
 
 #[derive(Clone, Debug, PartialEq)]
+/// Query parameters defining a channel, time range and number of posts.
 pub struct ChannelOptions {
     pub channel: Channel,
     pub time_start: Timestamp,
     pub time_end: Timestamp,
     pub limit: usize,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+/// Information self-published by a user.
+pub struct UserInfo {
+    pub key: String,
+    pub val: String,
+}
+
+impl UserInfo {
+    /// Create a new instance of `UserInfo`.
+    pub fn new<T: Into<String>, U: Into<String>>(key: T, val: U) -> Self {
+        UserInfo {
+            key: key.into(),
+            val: val.into(),
+        }
+    }
+
+    /// Create an instance of `UserInfo` to set a user's display name.
+    pub fn name<T: Into<String>>(username: T) -> Result<Self, Error> {
+        let name = username.into();
+        // Determine the length of the given username in UTF-8 codepoints.
+        let name_len = name.chars().count();
+        // The name must be between 1 and 32 codepoints.
+        if !(1..=32).contains(&name_len) {
+            return CableErrorKind::UsernameLengthIncorrect {
+                name,
+                len: name_len,
+            }
+            .raise();
+        }
+
+        Ok(UserInfo::new("name", name))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::{Error, UserInfo};
+
+    #[test]
+    fn validate_username() -> Result<(), Error> {
+        // Test valid usernames.
+        let _valid_name = UserInfo::name("glyph")?;
+        let _valid_name_japanese = UserInfo::name("五十嵐大介")?;
+
+        // Test invalid usernames.
+
+        // Name too short.
+        match UserInfo::name("") {
+            Err(e) => assert_eq!(
+                e.to_string(),
+                "expected username between 1 and 32 codepoints; name `` is 0 codepoints"
+            ),
+            _ => panic!(),
+        }
+
+        // Name too long.
+        match UserInfo::name("Kimmeridgebrachypteraeschnidium etchesi") {
+            Err(e) => assert_eq!(
+                e.to_string(),
+                "expected username between 1 and 32 codepoints; name `Kimmeridgebrachypteraeschnidium etchesi` is 39 codepoints"
+            ),
+            _ => panic!(),
+        }
+
+        Ok(())
+    }
 }

--- a/cable/src/post.rs
+++ b/cable/src/post.rs
@@ -15,25 +15,8 @@ use sodiumoxide::crypto::{
 
 use crate::{
     error::{CableErrorKind, Error},
-    Channel, Hash, Text, Topic,
+    Channel, Hash, Text, Topic, UserInfo,
 };
-
-#[derive(Clone, Debug, PartialEq)]
-/// Information self-published by a user.
-pub struct UserInfo {
-    pub key: String,
-    pub val: String,
-}
-
-impl UserInfo {
-    /// Convenience method to construct `UserInfo`.
-    pub fn new<T: Into<String>, U: Into<String>>(key: T, val: U) -> Self {
-        UserInfo {
-            key: key.into(),
-            val: val.into(),
-        }
-    }
-}
 
 /// The data of an encoded post.
 pub type EncodedPost = Vec<u8>;

--- a/cable/src/post.rs
+++ b/cable/src/post.rs
@@ -239,14 +239,6 @@ impl ToBytes for Post {
     fn write_bytes(&self, buf: &mut [u8]) -> Result<usize, Error> {
         let mut offset = 0;
 
-        // Validate the length of the public key, signature and links fields.
-        // TODO: Rather raise an appropriate CableErrorKind here.
-        assert_eq![self.header.public_key.len(), 32];
-        assert_eq![self.header.signature.len(), 64];
-        for link in &self.header.links {
-            assert_eq![link.len(), 32]
-        }
-
         /* POST HEADER BYTES */
 
         // Write the public key bytes to the buffer and increment the offset.

--- a/cable/src/post.rs
+++ b/cable/src/post.rs
@@ -396,9 +396,12 @@ impl FromBytes for Post {
                 let (s, channel_len) = varint::decode(&buf[offset..])?;
                 offset += s;
 
-                // Read the channel bytes and increment the offset.
+                // Read the channel bytes.
                 let channel =
                     String::from_utf8(buf[offset..offset + channel_len as usize].to_vec())?;
+                // Validate the length of the channel name.
+                crate::validate_channel(&channel)?;
+                // Increment the offset.
                 offset += channel_len as usize;
 
                 // Read the text length byte and increment the offset.
@@ -466,7 +469,12 @@ impl FromBytes for Post {
                     let val = String::from_utf8(buf[offset..offset + val_len as usize].to_vec())?;
                     offset += val_len as usize;
 
-                    let key_val = UserInfo::new(key, val);
+                    let key_val = if key == "name" {
+                        // This method also performs validation.
+                        UserInfo::name(val)?
+                    } else {
+                        UserInfo::new(key, val)
+                    };
 
                     info.push(key_val);
                 }
@@ -479,17 +487,23 @@ impl FromBytes for Post {
                 let (s, channel_len) = varint::decode(&buf[offset..])?;
                 offset += s;
 
-                // Read the channel bytes and increment the offset.
+                // Read the channel bytes.
                 let channel =
                     String::from_utf8(buf[offset..offset + channel_len as usize].to_vec())?;
+                // Validate the length of the channel name.
+                crate::validate_channel(&channel)?;
+                // Increment the offset.
                 offset += channel_len as usize;
 
                 // Read the topic length byte and increment the offset.
                 let (s, topic_len) = varint::decode(&buf[offset..])?;
                 offset += s;
 
-                // Read the topic bytes and increment the offset.
+                // Read the topic bytes.
                 let topic = String::from_utf8(buf[offset..offset + topic_len as usize].to_vec())?;
+                // Validate the length of the topic.
+                crate::validate_topic(&topic)?;
+                // Increment the offset.
                 offset += topic_len as usize;
 
                 PostBody::Topic { channel, topic }
@@ -500,9 +514,12 @@ impl FromBytes for Post {
                 let (s, channel_len) = varint::decode(&buf[offset..])?;
                 offset += s;
 
-                // Read the channel bytes and increment the offset.
+                // Read the channel bytes.
                 let channel =
                     String::from_utf8(buf[offset..offset + channel_len as usize].to_vec())?;
+                // Validate the length of the channel name.
+                crate::validate_channel(&channel)?;
+                // Increment the offset.
                 offset += channel_len as usize;
 
                 PostBody::Join { channel }
@@ -513,9 +530,12 @@ impl FromBytes for Post {
                 let (s, channel_len) = varint::decode(&buf[offset..])?;
                 offset += s;
 
-                // Read the channel bytes and increment the offset.
+                // Read the channel bytes.
                 let channel =
                     String::from_utf8(buf[offset..offset + channel_len as usize].to_vec())?;
+                // Validate the length of the channel name.
+                crate::validate_channel(&channel)?;
+                // Increment the offset.
                 offset += channel_len as usize;
 
                 PostBody::Leave { channel }


### PR DESCRIPTION
This PR adds length validation checks for channel, name and topic.

A passing test has been added for each (with checks for valid and invalid values).

The validators have been incorporated into the `FromBytes` implementation for `Post` to ensure that deserialized binaries conform to the specification.