### PR TITLE
Vendor length-prefixed-stream and update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,5 +3,6 @@
 members = [
     "cable",
     "cable_core",
-    "desert"
+    "desert",
+    "length_prefixed_stream"
 ]

--- a/README.md
+++ b/README.md
@@ -9,3 +9,4 @@ Experimental [cable](https://github.com/cabal-club/cable) protocol implementatio
 - [cable](cable/) : Cable binary payload encoding and decoding (plus post and message types)
 - [cable_core](cable_core/) : Store and stream implementations for creating cable peers
 - [desert](desert/) : Serialization and deserialization traits (vendored version; authored by substack)
+- [length_prefixed_stream](length_prefixed_stream/) : Decoder to convert a byte stream of varint length-encoded messages into a stream of chunks (vendored version; authored by substack)

--- a/cable_core/Cargo.toml
+++ b/cable_core/Cargo.toml
@@ -4,14 +4,14 @@ version = "1.0.0"
 edition = "2021"
 
 [dependencies]
-async-std = { version = "1.10.0", features = ["attributes","unstable"] }
-async-trait = "0.1.51"
+async-std = { version = "1.12.0", features = ["attributes","unstable"] }
+async-trait = "0.1.71"
 cable = { path = "../cable" }
-futures = "0.3.13"
+futures = "0.3.28"
 desert = { path = "../desert" }
-#length-prefixed-stream = "1.0.0"
-signature = "1.3.1"
+length-prefixed-stream = { path = "../length_prefixed_stream" }
+signature = "2.1.0"
 sodiumoxide = "0.2.7"
 
 [dev-dependencies]
-argmap = "1.1.1"
+argmap = "1.1.2"

--- a/length_prefixed_stream/Cargo.toml
+++ b/length_prefixed_stream/Cargo.toml
@@ -9,6 +9,6 @@ version = "1.0.0"
 [dependencies]
 async-std = "1.9.0"
 desert = { path = "../desert" }
-futures = "0.3.12"
-futures-core = "0.3.12"
-pin-project-lite = "0.2.4"
+futures = "0.3.28"
+futures-core = "0.3.28"
+pin-project-lite = "0.2.10"

--- a/length_prefixed_stream/Cargo.toml
+++ b/length_prefixed_stream/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+description = "decode a byte stream of varint length-encoded messages into a stream of chunks"
+edition = "2018"
+license = "BSD-3-Clause"
+name = "length-prefixed-stream"
+readme = "readme.md"
+version = "1.0.0"
+
+[dependencies]
+async-std = "1.9.0"
+desert = { path = "../desert" }
+futures = "0.3.12"
+futures-core = "0.3.12"
+pin-project-lite = "0.2.4"

--- a/length_prefixed_stream/LICENSE
+++ b/length_prefixed_stream/LICENSE
@@ -1,0 +1,22 @@
+Copyright (c) 2021 James Halliday
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list
+of conditions and the following disclaimer.
+
+Redistributions in binary form must reproduce the above copyright notice, this
+list of conditions and the following disclaimer in the documentation and/or
+other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/length_prefixed_stream/README.md
+++ b/length_prefixed_stream/README.md
@@ -1,0 +1,35 @@
+# length-prefixed-stream
+
+decode a byte stream of varint length-encoded messages into a stream of chunks
+
+This crate is similar to and compatible with the
+[javascript length-prefixed-stream](https://www.npmjs.com/package/length-prefixed-stream) package.
+
+# example
+
+``` rust
+use async_std::{prelude::*,stream,task};
+use length_prefixed_stream::decode;
+use futures::{stream::TryStreamExt};
+type Error = Box<dyn std::error::Error+Send+Sync+'static>;
+
+// this program will print:
+// [97,98,99,100,101,102]
+// [65,66,67,68]
+
+fn main() -> Result<(),Error> {
+  task::block_on(async {
+    let input = stream::from_iter(vec![
+      Ok(vec![6,97,98,99]),
+      Ok(vec![100,101]),
+      Ok(vec![102,4,65,66]),
+      Ok(vec![67,68]),
+    ]).into_async_read();
+    let mut decoder = decode(input);
+    while let Some(chunk) = decoder.next().await {
+      println!["{:?}", chunk?];
+    }
+    Ok(())
+  })
+}
+```

--- a/length_prefixed_stream/README.md
+++ b/length_prefixed_stream/README.md
@@ -1,35 +1,36 @@
 # length-prefixed-stream
 
-decode a byte stream of varint length-encoded messages into a stream of chunks
+Decode a byte stream of varint length-encoded messages into a stream of chunks.
 
 This crate is similar to and compatible with the
 [javascript length-prefixed-stream](https://www.npmjs.com/package/length-prefixed-stream) package.
 
 # example
 
-``` rust
-use async_std::{prelude::*,stream,task};
+```rust
+use async_std::{prelude::*, stream, task};
+use futures::stream::TryStreamExt;
 use length_prefixed_stream::decode;
-use futures::{stream::TryStreamExt};
-type Error = Box<dyn std::error::Error+Send+Sync+'static>;
+type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
 
 // this program will print:
 // [97,98,99,100,101,102]
 // [65,66,67,68]
 
-fn main() -> Result<(),Error> {
-  task::block_on(async {
-    let input = stream::from_iter(vec![
-      Ok(vec![6,97,98,99]),
-      Ok(vec![100,101]),
-      Ok(vec![102,4,65,66]),
-      Ok(vec![67,68]),
-    ]).into_async_read();
-    let mut decoder = decode(input);
-    while let Some(chunk) = decoder.next().await {
-      println!["{:?}", chunk?];
-    }
-    Ok(())
-  })
+fn main() -> Result<(), Error> {
+    task::block_on(async {
+        let input = stream::from_iter(vec![
+            Ok(vec![6, 97, 98, 99]),
+            Ok(vec![100, 101]),
+            Ok(vec![102, 4, 65, 66]),
+            Ok(vec![67, 68]),
+        ])
+        .into_async_read();
+        let mut decoder = decode(input);
+        while let Some(chunk) = decoder.next().await {
+            println!["{:?}", chunk?];
+        }
+        Ok(())
+    })
 }
 ```

--- a/length_prefixed_stream/examples/decode.rs
+++ b/length_prefixed_stream/examples/decode.rs
@@ -1,0 +1,25 @@
+use async_std::{prelude::*, stream, task};
+use futures::stream::TryStreamExt;
+use length_prefixed_stream::decode;
+type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
+
+// this program will print:
+// [97,98,99,100,101,102]
+// [65,66,67,68]
+
+fn main() -> Result<(), Error> {
+    task::block_on(async {
+        let input = stream::from_iter(vec![
+            Ok(vec![6, 97, 98, 99]),
+            Ok(vec![100, 101]),
+            Ok(vec![102, 4, 65, 66]),
+            Ok(vec![67, 68]),
+        ])
+        .into_async_read();
+        let mut decoder = decode(input);
+        while let Some(chunk) = decoder.next().await {
+            println!["{:?}", chunk?];
+        }
+        Ok(())
+    })
+}

--- a/length_prefixed_stream/src/error.rs
+++ b/length_prefixed_stream/src/error.rs
@@ -1,0 +1,74 @@
+pub type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
+use std::backtrace::Backtrace;
+
+#[derive(Debug)]
+pub struct DecodeError {
+    kind: DecodeErrorKind,
+    backtrace: Backtrace,
+}
+
+#[derive(Debug)]
+pub enum DecodeErrorKind {
+    Source { error: Error },
+    UnexpectedEndVarint {},
+    UnexpectedEndMessage {},
+}
+
+impl DecodeErrorKind {
+    pub fn raise<T>(self) -> Result<T, DecodeError> {
+        Err(DecodeError {
+            kind: self,
+            backtrace: Backtrace::capture(),
+        })
+    }
+}
+
+impl std::error::Error for DecodeError {
+    /*
+    fn source(&'_ self) -> Option<&'_ (dyn std::error::Error+'static)> {
+      match self.kind {
+        DecodeErrorKind::Source { error } => Some(error),
+        _ => None,
+      }
+    }
+    */
+    fn backtrace(&'_ self) -> Option<&'_ Backtrace> {
+        Some(&self.backtrace)
+    }
+}
+
+impl From<Error> for DecodeError {
+    fn from(error: Error) -> Self {
+        DecodeError {
+            kind: DecodeErrorKind::Source { error },
+            backtrace: Backtrace::capture(),
+        }
+    }
+}
+
+impl From<std::io::Error> for DecodeError {
+    fn from(error: std::io::Error) -> Self {
+        DecodeError {
+            kind: DecodeErrorKind::Source {
+                error: Box::new(error),
+            },
+            backtrace: Backtrace::capture(),
+        }
+    }
+}
+
+impl std::fmt::Display for DecodeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match &self.kind {
+            DecodeErrorKind::Source { error } => {
+                write![f, "{}", error]
+            }
+            DecodeErrorKind::UnexpectedEndVarint {} => {
+                write![f, "unexpected end of input stream while decoding varint"]
+            }
+            DecodeErrorKind::UnexpectedEndMessage {} => {
+                write![f, "unexpected end of input stream while decoding message"]
+            }
+        }
+    }
+}

--- a/length_prefixed_stream/src/error.rs
+++ b/length_prefixed_stream/src/error.rs
@@ -1,9 +1,12 @@
-pub type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
+#[cfg(feature = "nightly-features")]
 use std::backtrace::Backtrace;
+
+pub type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
 
 #[derive(Debug)]
 pub struct DecodeError {
     kind: DecodeErrorKind,
+    #[cfg(feature = "nightly-features")]
     backtrace: Backtrace,
 }
 
@@ -18,20 +21,14 @@ impl DecodeErrorKind {
     pub fn raise<T>(self) -> Result<T, DecodeError> {
         Err(DecodeError {
             kind: self,
+            #[cfg(feature = "nightly-features")]
             backtrace: Backtrace::capture(),
         })
     }
 }
 
 impl std::error::Error for DecodeError {
-    /*
-    fn source(&'_ self) -> Option<&'_ (dyn std::error::Error+'static)> {
-      match self.kind {
-        DecodeErrorKind::Source { error } => Some(error),
-        _ => None,
-      }
-    }
-    */
+    #[cfg(feature = "nightly-features")]
     fn backtrace(&'_ self) -> Option<&'_ Backtrace> {
         Some(&self.backtrace)
     }
@@ -41,6 +38,7 @@ impl From<Error> for DecodeError {
     fn from(error: Error) -> Self {
         DecodeError {
             kind: DecodeErrorKind::Source { error },
+            #[cfg(feature = "nightly-features")]
             backtrace: Backtrace::capture(),
         }
     }
@@ -52,6 +50,7 @@ impl From<std::io::Error> for DecodeError {
             kind: DecodeErrorKind::Source {
                 error: Box::new(error),
             },
+            #[cfg(feature = "nightly-features")]
             backtrace: Backtrace::capture(),
         }
     }

--- a/length_prefixed_stream/src/lib.rs
+++ b/length_prefixed_stream/src/lib.rs
@@ -6,7 +6,7 @@
 // and released under the BSD-3-CLAUSE license:
 // https://docs.rs/crate/length-prefixed-stream/1.0.0/source/LICENSE
 
-#![feature(async_closure, backtrace)]
+#![cfg_attr(feature = "nightly-features", feature(async_closure, backtrace))]
 #![allow(unused_assignments)]
 #![doc=include_str!("../README.md")]
 
@@ -33,6 +33,7 @@ pub fn decode_with_options(
     options: DecodeOptions,
 ) -> Box<dyn Stream<Item = Result<Vec<u8>, DecodeError>> + Send + Sync + Unpin> {
     let state = Decoder::new(input, options);
+    #[cfg(feature = "async_closure")]
     Box::new(unfold(state, async move |mut state| {
         match state.next().await {
             Ok(Some(x)) => Some((Ok(x), state)),

--- a/length_prefixed_stream/src/lib.rs
+++ b/length_prefixed_stream/src/lib.rs
@@ -1,5 +1,7 @@
 // Vendored version of length-prefixed-stream 1.0.0
 //
+// Minor changes have been made to fix compilation errors.
+//
 // The original source files from which this is derived is
 // Copyright (c) 2021 James Halliday
 //

--- a/length_prefixed_stream/src/lib.rs
+++ b/length_prefixed_stream/src/lib.rs
@@ -1,0 +1,168 @@
+// Vendored version of length-prefixed-stream 1.0.0
+//
+// The original source files from which this is derived is
+// Copyright (c) 2021 James Halliday
+//
+// and released under the BSD-3-CLAUSE license:
+// https://docs.rs/crate/length-prefixed-stream/1.0.0/source/LICENSE
+
+#![feature(async_closure, backtrace)]
+#![allow(unused_assignments)]
+#![doc=include_str!("../README.md")]
+
+use async_std::{prelude::*, stream::Stream};
+use desert::varint;
+use futures::io::AsyncRead;
+use std::collections::VecDeque;
+use std::marker::Unpin;
+
+mod unfold;
+use unfold::unfold;
+mod error;
+use error::DecodeErrorKind as EK;
+pub use error::{DecodeError, DecodeErrorKind};
+
+pub fn decode(
+    input: impl AsyncRead + Send + Sync + Unpin + 'static,
+) -> Box<dyn Stream<Item = Result<Vec<u8>, DecodeError>> + Send + Sync + Unpin> {
+    decode_with_options(input, DecodeOptions::default())
+}
+
+pub fn decode_with_options(
+    input: impl AsyncRead + Send + Sync + Unpin + 'static,
+    options: DecodeOptions,
+) -> Box<dyn Stream<Item = Result<Vec<u8>, DecodeError>> + Send + Sync + Unpin> {
+    let state = Decoder::new(input, options);
+    Box::new(unfold(state, async move |mut state| {
+        match state.next().await {
+            Ok(Some(x)) => Some((Ok(x), state)),
+            Ok(None) => None,
+            Err(e) => Some((Err(e.into()), state)),
+        }
+    }))
+}
+
+pub struct DecodeOptions {
+    pub max_size: usize,
+    pub include_len: bool,
+}
+
+impl Default for DecodeOptions {
+    fn default() -> Self {
+        Self {
+            max_size: 50_000,
+            include_len: false,
+        }
+    }
+}
+
+struct Decoder<AR: AsyncRead> {
+    input: AR,
+    buffer: Vec<u8>,
+    queue: VecDeque<Vec<u8>>,
+    write_offset: usize,
+    options: DecodeOptions,
+}
+
+impl<AR> Decoder<AR>
+where
+    AR: AsyncRead + Unpin + 'static,
+{
+    pub fn new(input: AR, options: DecodeOptions) -> Self {
+        Self {
+            input,
+            buffer: vec![0u8; options.max_size],
+            write_offset: 0,
+            queue: VecDeque::new(),
+            options,
+        }
+    }
+    pub async fn next(&mut self) -> Result<Option<Vec<u8>>, DecodeError> {
+        if let Some(buf) = self.queue.pop_front() {
+            return Ok(Some(buf));
+        }
+        let mut msg_len = 0;
+        let mut read_offset = 0;
+        loop {
+            let n = self
+                .input
+                .read(&mut self.buffer[self.write_offset..])
+                .await?;
+            if n == 0 && self.write_offset == 0 {
+                return Ok(None);
+            } else if n == 0 {
+                return EK::UnexpectedEndVarint {}.raise();
+            }
+            self.write_offset += n;
+            match varint::decode(&self.buffer) {
+                Ok((s, len)) => {
+                    msg_len = len as usize;
+                    read_offset = s;
+                    break;
+                }
+                Err(e) => {
+                    if self.write_offset >= 10 {
+                        return Err(e.into());
+                    }
+                }
+            }
+        }
+        loop {
+            if msg_len == 0 {
+                break;
+            }
+            if msg_len + read_offset > self.write_offset {
+                let n = self
+                    .input
+                    .read(&mut self.buffer[self.write_offset..])
+                    .await?;
+                if n == 0 {
+                    return EK::UnexpectedEndMessage {}.raise();
+                }
+                self.write_offset += n;
+            } else {
+                break;
+            }
+        }
+        let buf = {
+            if self.options.include_len {
+                self.buffer[0..read_offset + msg_len].to_vec()
+            } else {
+                self.buffer[read_offset..read_offset + msg_len].to_vec()
+            }
+        };
+        {
+            let mut offset = read_offset + msg_len;
+            let mut vlen = 0;
+            loop {
+                // push remaining complete records in this buffer to queue
+                match varint::decode(&self.buffer[offset..]) {
+                    Ok((s, len)) => {
+                        msg_len = len as usize;
+                        vlen = s;
+                    }
+                    _ => break,
+                }
+                if msg_len == 0 {
+                    break;
+                }
+                if offset + vlen + msg_len > self.write_offset {
+                    break;
+                }
+                offset += vlen;
+                let qbuf = {
+                    if self.options.include_len {
+                        self.buffer[offset - vlen..offset + msg_len].to_vec()
+                    } else {
+                        self.buffer[offset..offset + msg_len].to_vec()
+                    }
+                };
+                self.queue.push_back(qbuf);
+                offset += msg_len;
+            }
+            self.buffer.copy_within(offset.., 0);
+            self.write_offset -= offset;
+        }
+        Ok(Some(buf))
+    }
+}

--- a/length_prefixed_stream/src/unfold.rs
+++ b/length_prefixed_stream/src/unfold.rs
@@ -1,0 +1,78 @@
+// vendored version of futures::stream::unfold
+// modified to use async_std
+
+// The original source file from which this is derived is
+// Copyright (c) 2016 Alex Crichton
+// Copyright (c) 2017 The Tokio Authors
+
+// and released under the MIT or APACHE license:
+// https://github.com/rust-lang/futures-rs/blob/master/LICENSE-MIT
+// https://github.com/rust-lang/futures-rs/blob/master/LICENSE-APACHE
+
+use async_std::future::Future;
+use async_std::stream::Stream;
+use async_std::task::{Context, Poll};
+use core::fmt;
+use core::pin::Pin;
+use futures_core::ready;
+
+pub fn unfold<T, F, Fut, It>(init: T, f: F) -> Unfold<T, F, Fut>
+where
+    F: FnMut(T) -> Fut,
+    Fut: Future<Output = Option<(It, T)>>,
+{
+    Unfold {
+        f,
+        state: Some(init),
+        fut: None,
+    }
+}
+
+pin_project_lite::pin_project! {
+  /// Stream for the [`unfold`] function.
+  #[must_use = "streams do nothing unless polled"]
+  pub struct Unfold<T, F, Fut> {
+    f: F,
+    state: Option<T>,
+    fut: Option<Pin<Box<Fut>>>,
+  }
+}
+
+impl<T, F, Fut> fmt::Debug for Unfold<T, F, Fut>
+where
+    T: fmt::Debug,
+    Fut: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Unfold")
+            .field("state", &self.state)
+            .field("fut", &self.fut)
+            .finish()
+    }
+}
+
+impl<T, F, Fut, It> Stream for Unfold<T, F, Fut>
+where
+    F: FnMut(T) -> Fut,
+    Fut: Future<Output = Option<(It, T)>>,
+{
+    type Item = It;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<It>> {
+        let this = self.project();
+        if let Some(state) = this.state.take() {
+            let fut = (this.f)(state);
+            *this.fut = Some(Box::pin(fut));
+        }
+
+        let step = ready!(Pin::new(this.fut.as_mut().unwrap()).poll(cx));
+        *this.fut = None;
+
+        if let Some((item, next_state)) = step {
+            *this.state = Some(next_state);
+            Poll::Ready(Some(item))
+        } else {
+            Poll::Ready(None)
+        }
+    }
+}

--- a/length_prefixed_stream/tests/decode.rs
+++ b/length_prefixed_stream/tests/decode.rs
@@ -1,0 +1,87 @@
+use async_std::{prelude::*, stream, task};
+use futures::stream::TryStreamExt;
+use length_prefixed_stream::decode;
+type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
+
+#[test]
+fn simple_0() -> Result<(), Error> {
+    task::block_on(async {
+        let input = stream::from_iter(vec![
+            Ok(vec![6, 97, 98, 99]),
+            Ok(vec![100, 101]),
+            Ok(vec![102, 4, 65, 66]),
+            Ok(vec![67, 68]),
+        ])
+        .into_async_read();
+        let mut decoder = decode(input);
+        let mut observed = vec![];
+        while let Some(chunk) = decoder.next().await {
+            observed.push(chunk?);
+        }
+        assert_eq![
+            observed,
+            vec![vec![97, 98, 99, 100, 101, 102], vec![65, 66, 67, 68],]
+        ];
+        Ok(())
+    })
+}
+
+#[test]
+fn simple_1() -> Result<(), Error> {
+    task::block_on(async {
+        let input = stream::from_iter(vec![
+            Ok(vec![3, 10, 20, 30, 5]),
+            Ok(vec![11, 12, 13, 14, 15]),
+            Ok(vec![1, 6, 3, 103]),
+            Ok(vec![102, 101]),
+        ])
+        .into_async_read();
+        let mut decoder = decode(input);
+        let mut observed = vec![];
+        while let Some(chunk) = decoder.next().await {
+            observed.push(chunk?);
+        }
+        assert_eq![
+            observed,
+            vec![
+                vec![10, 20, 30],
+                vec![11, 12, 13, 14, 15],
+                vec![6],
+                vec![103, 102, 101],
+            ]
+        ];
+        Ok(())
+    })
+}
+
+#[test]
+fn multibyte_msg_len() -> Result<(), Error> {
+    task::block_on(async {
+        let input = stream::from_iter(vec![
+            Ok(vec![4, 200, 201, 202, 203, 144]), // encode(400) = [144,3]
+            Ok([vec![3], (0..200).collect()].concat()),
+            Ok((200..395).map(|c| (c % 256) as u8).collect()),
+            Ok([(395..400).map(|c| (c % 256) as u8).collect(), vec![5, 99]].concat()),
+            Ok(vec![98, 97, 96]),
+            Ok(vec![95, 4, 150, 150, 150, 150, 1]),
+            Ok(vec![55]),
+        ])
+        .into_async_read();
+        let mut decoder = decode(input);
+        let mut observed = vec![];
+        while let Some(chunk) = decoder.next().await {
+            observed.push(chunk?);
+        }
+        assert_eq![
+            observed,
+            vec![
+                vec![200, 201, 202, 203],
+                (0..400).map(|c| (c % 256) as u8).collect(),
+                vec![99, 98, 97, 96, 95],
+                vec![150, 150, 150, 150],
+                vec![55],
+            ]
+        ];
+        Ok(())
+    })
+}

--- a/length_prefixed_stream/tests/options.rs
+++ b/length_prefixed_stream/tests/options.rs
@@ -1,0 +1,29 @@
+use async_std::{prelude::*, stream, task};
+use futures::stream::TryStreamExt;
+use length_prefixed_stream::{decode_with_options, DecodeOptions};
+type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
+
+#[test]
+fn options_include_len() -> Result<(), Error> {
+    task::block_on(async {
+        let input = stream::from_iter(vec![
+            Ok(vec![6, 97, 98, 99]),
+            Ok(vec![100, 101]),
+            Ok(vec![102, 4, 65, 66]),
+            Ok(vec![67, 68]),
+        ])
+        .into_async_read();
+        let mut options = DecodeOptions::default();
+        options.include_len = true;
+        let mut decoder = decode_with_options(input, options);
+        let mut observed = vec![];
+        while let Some(chunk) = decoder.next().await {
+            observed.push(chunk?);
+        }
+        assert_eq![
+            observed,
+            vec![vec![6, 97, 98, 99, 100, 101, 102], vec![4, 65, 66, 67, 68],]
+        ];
+        Ok(())
+    })
+}


### PR DESCRIPTION
This PR vendors the [length-prefixed-stream](https://crates.io/crates/length-prefixed-stream) library authored by substack.

The original code has been modified to fix compilation errors, update dependencies and introduce idiomatic formatting.

Tests are passing.