### PR TITLE
Implement `close_channel` and improve request tracking

### DIFF
--- a/cable/src/message.rs
+++ b/cable/src/message.rs
@@ -33,6 +33,14 @@ impl Message {
         Message { header, body }
     }
 
+    /// Decrement the TTL of a request-type message by one.
+    pub fn decrement_ttl(&mut self) {
+        // TODO: Ensure this works as intended.
+        if let MessageBody::Request { ref mut ttl, .. } = self.body {
+            *ttl -= 1
+        }
+    }
+
     /// Return the numeric type identifier for the message.
     pub fn message_type(&self) -> u64 {
         match &self.body {

--- a/cable_core/Cargo.toml
+++ b/cable_core/Cargo.toml
@@ -10,6 +10,7 @@ cable = { path = "../cable" }
 futures = "0.3.28"
 desert = { path = "../desert" }
 length-prefixed-stream = { path = "../length_prefixed_stream" }
+log = "0.4.19"
 signature = "2.1.0"
 sodiumoxide = "0.2.7"
 

--- a/cable_core/src/lib.rs
+++ b/cable_core/src/lib.rs
@@ -6,8 +6,4 @@ mod store;
 mod stream;
 
 pub use manager::CableManager;
-<<<<<<< Updated upstream
 pub use store::MemoryStore;
-=======
-pub use store::{MemoryStore, Store};
->>>>>>> Stashed changes

--- a/cable_core/src/lib.rs
+++ b/cable_core/src/lib.rs
@@ -6,4 +6,8 @@ mod store;
 mod stream;
 
 pub use manager::CableManager;
+<<<<<<< Updated upstream
 pub use store::MemoryStore;
+=======
+pub use store::{MemoryStore, Store};
+>>>>>>> Stashed changes

--- a/cable_core/src/store.rs
+++ b/cable_core/src/store.rs
@@ -99,7 +99,6 @@ pub trait Store: Clone + Send + Sync + Unpin + 'static {
     async fn want(&mut self, hashes: &[Hash]) -> Result<Vec<Hash>, Error>;
 
     /// Retrieve the post payloads for all posts represented by the given hashes.
-    // TODO: Consider renaming to `get_encoded_posts()`.
     async fn get_post_payloads(&mut self, hashes: &[Hash]) -> Result<Vec<Payload>, Error>;
 }
 
@@ -175,9 +174,6 @@ impl Store for MemoryStore {
         } else {
             None
         }
-
-        // TODO: Return the latest post hash, if available, instead of zeros.
-        //Ok([0; 32])
     }
 
     async fn insert_channels(&mut self, channels: &[Channel]) -> Result<(), Error> {
@@ -281,6 +277,7 @@ impl Store for MemoryStore {
                             .insert(hash, post.to_bytes()?);
                     }
                 }
+
                 // If we have open live streams matching the channel to which
                 // this post was published...
                 if let Some(senders) = self.live_streams.read().await.get(channel) {

--- a/cable_core/src/store.rs
+++ b/cable_core/src/store.rs
@@ -63,9 +63,13 @@ pub trait Store: Clone + Send + Sync + Unpin + 'static {
         }
     }
 
-    /// Retrieve the hash of the most recently published post in the given
-    /// channel.
-    async fn get_latest_hash(&mut self, channel: &Channel) -> Result<Hash, Error>;
+    /// Retrieve the hash(es) of the most recently published post(s) in the
+    /// given channel.
+    ///
+    /// More than one hash will be returned if several posts were
+    /// made to the same channel at the same time. Usually though, only one
+    /// hash or no hashes will be returned.
+    async fn get_latest_hashes(&mut self, channel: &Channel) -> Option<Vec<Hash>>;
 
     /// Insert the given channels into the store.
     async fn insert_channels(&mut self, channels: &[Channel]) -> Result<(), Error>;
@@ -158,9 +162,22 @@ impl Store for MemoryStore {
         Ok(())
     }
 
-    async fn get_latest_hash(&mut self, _channel: &Channel) -> Result<Hash, Error> {
+    async fn get_latest_hashes(&mut self, channel: &Channel) -> Option<Vec<Hash>> {
+        // Open the post hashes store for reading.
+        let post_hashes_map = self.post_hashes.read().await;
+
+        // Get the BTree associated with the given channel.
+        if let Some(post_hashes_btree) = post_hashes_map.get(channel) {
+            // Return the most recently added hash(es).
+            post_hashes_btree
+                .last_key_value()
+                .map(|(_, hash)| hash.to_owned())
+        } else {
+            None
+        }
+
         // TODO: Return the latest post hash, if available, instead of zeros.
-        Ok([0; 32])
+        //Ok([0; 32])
     }
 
     async fn insert_channels(&mut self, channels: &[Channel]) -> Result<(), Error> {


### PR DESCRIPTION
This PR adds the foundation for `CableManager` testing (currently failing), as well as a few other improvements.

- Implements `close_channel()` to cancel a locally-generated channel time range request
- Handles decrementing of TTL for received requests
- Adds received requests to `outbound_requests` store if TTL > 0
- Adds a `RequestOrigin` `enum` to be able to differentiate locally and remotely-generated requests
- Renames `inbound_requests` to `live_requests`