### PR TITLE
Add indexes, related methods and tests for channel state

### DIFF
--- a/cable/src/lib.rs
+++ b/cable/src/lib.rs
@@ -31,6 +31,8 @@ pub type Text = String;
 pub type Timestamp = u64;
 /// The topic of a channel.
 pub type Topic = String;
+/// The nickname of a peer.
+pub type Nickname = String;
 
 #[derive(Clone, Debug, PartialEq)]
 /// Query parameters defining a channel, time range and number of posts.

--- a/cable/src/post.rs
+++ b/cable/src/post.rs
@@ -244,6 +244,13 @@ impl Post {
         }
     }
 
+    /// Return the public key which authored the post.
+    pub fn get_public_key(&self) -> [u8; 32] {
+        let PostHeader { public_key, .. } = &self.header;
+
+        *public_key
+    }
+
     /// Return the timestamp of the post.
     pub fn get_timestamp(&self) -> u64 {
         let PostHeader { timestamp, .. } = &self.header;

--- a/cable_core/src/manager.rs
+++ b/cable_core/src/manager.rs
@@ -750,8 +750,7 @@ where
     /// requests originating locally and matching the given channel name.
     /// Broadcast the cancel request(s) to all peers.
     pub async fn close_channel(&self, channel: &String) -> Result<(), Error> {
-        debug!("Closing channel: {}", channel);
-
+        debug!("Closing channel {}", channel);
         let close_channel = channel;
 
         let mut outbound_requests = self.outbound_requests.write().await;
@@ -776,17 +775,8 @@ where
 
         for channel_req_id in channel_req_ids {
             let (_req_id, req_id_bytes) = self.new_req_id().await?;
-
             let request = Message::cancel_request(NO_CIRCUIT, req_id_bytes, TTL, channel_req_id);
-
-            // TODO: Do we really want to store a cancel request?
-            self.outbound_requests
-                .write()
-                .await
-                .insert(req_id_bytes, (RequestOrigin::Local, request.clone()));
-
             self.broadcast(&request).await?;
-
             outbound_requests.remove(&channel_req_id);
         }
 

--- a/cable_core/src/manager.rs
+++ b/cable_core/src/manager.rs
@@ -297,7 +297,7 @@ where
             // Retrieve all channels of which the author of the post is a
             // member and send post hashes for those channels. This ensures
             // that any "live" channel state requests for these channels
-            // receive the latest `post/info` hashes.
+            // receive the latest `post/info` and `post/delete` hashes.
             let public_key = post.get_public_key();
             let channels = self.store.get_channels().await?;
             for channel in channels {
@@ -345,16 +345,20 @@ where
                                 hashes.push(hash)
                             }
 
-                            // Return all info post hashes for members of
-                            // this channel.
-                            //
                             // Retrieve public keys of all channel members.
                             let channel_members = self.store.get_channel_members(channel).await?;
-                            // Retrieve info post hashes for each member's public key.
                             for public_key in channel_members {
+                                // Return all info post hashes for members of
+                                // this channel.
                                 let peer_info_hashes =
                                     self.store.get_info_hashes(&public_key).await;
                                 hashes.extend(peer_info_hashes);
+
+                                // Return all delete post hashes for members of
+                                // this channel.
+                                let peer_delete_hashes =
+                                    self.store.get_delete_hashes(&public_key).await;
+                                hashes.extend(peer_delete_hashes);
                             }
 
                             // Construct a new hash response message.

--- a/cable_core/src/manager.rs
+++ b/cable_core/src/manager.rs
@@ -348,17 +348,32 @@ where
                             // Retrieve public keys of all channel members.
                             let channel_members = self.store.get_channel_members(channel).await?;
                             for public_key in channel_members {
-                                // Return all info post hashes for members of
-                                // this channel.
-                                let peer_info_hashes =
-                                    self.store.get_info_hashes(&public_key).await;
-                                hashes.extend(peer_info_hashes);
-
                                 // Return all delete post hashes for members of
                                 // this channel.
                                 let peer_delete_hashes =
                                     self.store.get_delete_hashes(&public_key).await;
                                 hashes.extend(peer_delete_hashes);
+
+                                // Send the most-recent name-setting info
+                                // post hash for each peer.
+                                if let Some((_peer_name, peer_name_hash)) =
+                                    self.store.get_peer_name_and_hash(&public_key).await
+                                {
+                                    hashes.push(peer_name_hash)
+                                }
+                            }
+
+                            // Retrieve public keys of all ex-channel members.
+                            let ex_channel_members =
+                                self.store.get_ex_channel_members(channel).await?;
+                            for public_key in ex_channel_members {
+                                // Send the most-recent name-setting info
+                                // post hash for each peer.
+                                if let Some((_peer_name, peer_name_hash)) =
+                                    self.store.get_peer_name_and_hash(&public_key).await
+                                {
+                                    hashes.push(peer_name_hash)
+                                }
                             }
 
                             // Construct a new hash response message.

--- a/cable_core/src/store.rs
+++ b/cable_core/src/store.rs
@@ -105,6 +105,13 @@ pub trait Store: Clone + Send + Sync + Unpin + 'static {
         public_key: &PublicKey,
     ) -> Result<(), Error>;
 
+    /// Query whether the given public key is a member of the given channel.
+    async fn is_channel_member<'a>(
+        &'a mut self,
+        channel: &Channel,
+        public_key: &PublicKey,
+    ) -> Result<bool, Error>;
+
     /// Retrieve all members of the given channel.
     async fn get_channel_members<'a>(
         &'a mut self,
@@ -353,6 +360,16 @@ impl Store for MemoryStore {
             .unwrap_or(Vec::new());
 
         Ok(channel_members)
+    }
+
+    async fn is_channel_member(
+        &mut self,
+        channel: &Channel,
+        public_key: &PublicKey,
+    ) -> Result<bool, Error> {
+        let channel_members = self.get_channel_members(channel).await?;
+
+        Ok(channel_members.contains(public_key))
     }
 
     async fn update_channel_membership_hashes(

--- a/cable_core/src/store.rs
+++ b/cable_core/src/store.rs
@@ -120,6 +120,7 @@ pub trait Store: Clone + Send + Sync + Unpin + 'static {
         hash: &Hash,
     ) -> Result<(), Error>;
 
+    // TODO: Consider returning a `HashStream` instead of a vector.
     /// Retrieve all of the latest `post/join` or `post/leave` post hashes
     /// for the given channel.
     async fn get_channel_membership_hashes<'a>(
@@ -796,7 +797,9 @@ impl Store for MemoryStore {
             .flat_map(|(_time, posts)| posts.iter().map(|(_post, hash)| Ok(*hash)))
             .collect::<Vec<Result<Hash, Error>>>();
 
-        Ok(Box::new(stream::from_iter(hashes.into_iter())))
+        let hash_stream = Box::new(stream::from_iter(hashes.into_iter()));
+
+        Ok(hash_stream)
     }
 
     async fn get_post_payloads(&mut self, hashes: &[Hash]) -> Result<Vec<Payload>, Error> {

--- a/cable_core/src/store.rs
+++ b/cable_core/src/store.rs
@@ -178,6 +178,9 @@ pub trait Store: Clone + Send + Sync + Unpin + 'static {
     /// given public key.
     async fn insert_name(&mut self, public_key: &PublicKey, name: &Nickname);
 
+    /// Retrieve the nickname associated with the given public key.
+    async fn get_name(&mut self, public_key: &PublicKey) -> Option<Nickname>;
+
     /// Insert the given post into the store and return the hash.
     async fn insert_post(&mut self, post: &Post) -> Result<Hash, Error>;
 
@@ -509,6 +512,7 @@ impl Store for MemoryStore {
         Ok(())
     }
 
+    // TODO: Remove unnecessary `Result` return type.
     async fn get_channel_topic_and_hash<'a>(
         &'a mut self,
         channel: &Channel,
@@ -605,6 +609,10 @@ impl Store for MemoryStore {
     async fn insert_name(&mut self, public_key: &PublicKey, name: &Nickname) {
         let mut peer_names = self.peer_names.write().await;
         peer_names.insert(*public_key, name.to_owned());
+    }
+
+    async fn get_name(&mut self, public_key: &PublicKey) -> Option<Nickname> {
+        self.peer_names.read().await.get(public_key).cloned()
     }
 
     async fn insert_post(&mut self, post: &Post) -> Result<Hash, Error> {

--- a/cable_core/src/stream.rs
+++ b/cable_core/src/stream.rs
@@ -31,7 +31,9 @@ pub struct LiveStream {
 impl LiveStream {
     /// Create a new `LiveStream` with the given channel options and streams.
     pub fn new(id: usize, options: ChannelOptions, live_streams: Arc<RwLock<Vec<Self>>>) -> Self {
-        let (sender, receiver) = channel::bounded(options.limit as usize);
+        let limit = options.limit as usize;
+
+        let (sender, receiver) = channel::bounded(limit);
 
         Self {
             id,

--- a/cable_core/tests/channel_state.rs
+++ b/cable_core/tests/channel_state.rs
@@ -1,0 +1,301 @@
+//! Test channel state request / response.
+//!
+//! Create a cable manager by creating a TCP stream, invoke the cable listener
+//! and then write and read requests and responses to and from the stream.
+//!
+//! Run the test with debug logging enabled in a terminal:
+//!
+//! `RUST_LOG=debug cargo test channel_state_request_response`
+//!
+//! An outline of the actions taken in this test:
+//!
+//! 1) Publish a join post to the "entomology" channel.
+//!
+//! 2) Send a channel state request for the "entomology" channel. Ensure that
+//! a single hash is returned and that it matches the hash of the join post.
+
+use std::{thread, time::Duration};
+
+use async_std::{
+    net::{TcpListener, TcpStream},
+    stream::StreamExt,
+    task,
+};
+use cable::{
+    constants::{HASH_RESPONSE, NO_CIRCUIT},
+    message::{MessageBody, ResponseBody},
+    ChannelOptions, Error, Message,
+};
+use desert::{FromBytes, ToBytes};
+use futures::{AsyncReadExt, AsyncWriteExt};
+use log::info;
+
+use cable_core::{CableManager, MemoryStore};
+
+// The circuit_id field is not currently in use; set to all zeros.
+const CIRCUIT_ID: [u8; 4] = NO_CIRCUIT;
+const TTL: u8 = 1;
+
+// Initialise the logger in test mode.
+//
+// Set `is_test()` to `false` if you wish to see logging output during the
+// test run.
+fn init() {
+    let _ = env_logger::builder().is_test(false).try_init();
+}
+
+// Get the current system time in seconds since the UNIX epoch.
+fn now() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs()
+}
+
+#[async_std::test]
+async fn channel_state_request_response() -> Result<(), Error> {
+    init();
+
+    // Create a store and a cable manager.
+    let store = MemoryStore::default();
+    let mut cable = CableManager::new(store);
+    let cable_clone = cable.clone();
+
+    // Deploy a TCP listener.
+    //
+    // Assigning port to 0 means that the OS selects an available port for us.
+    let listener = TcpListener::bind("127.0.0.1:0").await?;
+
+    // Retrieve the address of the TCP listener to be able to connect later on.
+    let addr = listener.local_addr()?;
+    info!("Deployed TCP server on {}", addr);
+
+    task::spawn(async move {
+        // Listen for incoming TCP connections and pass any inbound streams to
+        // the cable manager.
+        let mut incoming = listener.incoming();
+        while let Some(stream) = incoming.next().await {
+            if let Ok(stream) = stream {
+                let cable = cable_clone.clone();
+                task::spawn(async move {
+                    cable.listen(stream).await.unwrap();
+                });
+            }
+        }
+    });
+
+    let mut stream = TcpStream::connect(addr).await?;
+    info!("Connected to TCP server on {}", addr);
+
+    let channel = "entomology".to_string();
+
+    // Publish a post to join the "entomology" channel.
+    let join_post_hash = cable.post_join(&channel).await?;
+
+    /* FIRST REQUEST */
+
+    // Generate a novel request ID.
+    let (_req_id, req_id_bytes) = cable.new_req_id().await?;
+
+    // Create a channel state request.
+    let channel_state_req =
+        Message::channel_state_request(CIRCUIT_ID, req_id_bytes, TTL, channel.clone(), 0);
+    let req_bytes = channel_state_req.to_bytes()?;
+
+    // Write the request bytes to the stream.
+    stream.write_all(&req_bytes).await?;
+
+    // Sleep briefly to allow time for the cable manager to respond.
+    let five_millis = Duration::from_millis(5);
+    thread::sleep(five_millis);
+
+    // Read the response from the stream.
+    let mut res_bytes = [0u8; 1024];
+    let _n = stream.read(&mut res_bytes).await?;
+
+    // Ensure that a hash response was returned by the listening peer.
+    let (_bytes_len, msg) = Message::from_bytes(&res_bytes)?;
+    assert_eq!(msg.message_type(), HASH_RESPONSE);
+
+    if let MessageBody::Response { body } = msg.body {
+        if let ResponseBody::Hash { hashes } = body {
+            // A single post hash should be returned.
+            assert_eq!(hashes.len(), 1);
+            // Ensure the returned hash matches the hash of the original
+            // join post.
+            assert_eq!(hashes[0], join_post_hash);
+        }
+    }
+
+    // Publish a post to leave the "entomology" channel.
+    let leave_post_hash = cable.post_leave(&channel).await?;
+
+    /* SECOND REQUEST */
+
+    // Generate a novel request ID.
+    let (_req_id, req_id_bytes) = cable.new_req_id().await?;
+
+    // Create a channel state request.
+    let channel_state_req =
+        Message::channel_state_request(CIRCUIT_ID, req_id_bytes, TTL, channel.clone(), 0);
+    let req_bytes = channel_state_req.to_bytes()?;
+
+    // Write the request bytes to the stream.
+    stream.write_all(&req_bytes).await?;
+
+    // Sleep briefly to allow time for the cable manager to respond.
+    let five_millis = Duration::from_millis(5);
+    thread::sleep(five_millis);
+
+    // Read the response from the stream.
+    let mut res_bytes = [0u8; 1024];
+    let _n = stream.read(&mut res_bytes).await?;
+
+    // Ensure that a hash response was returned by the listening peer.
+    let (_bytes_len, msg) = Message::from_bytes(&res_bytes)?;
+    assert_eq!(msg.message_type(), HASH_RESPONSE);
+
+    if let MessageBody::Response { body } = msg.body {
+        if let ResponseBody::Hash { hashes } = body {
+            // A single post hash should be returned.
+            assert_eq!(hashes.len(), 1);
+            // Ensure the returned hash matches the hash of the recent
+            // leave post.
+            assert_eq!(hashes[0], leave_post_hash);
+        }
+    }
+
+    // Set topic for channel.
+    // Get hash of channel topic.
+    // Update topic for channel.
+    // Get hash of channel topic.
+    // Delete latest topic for channel.
+    // Get hash of channel topic (must be the first topic).
+
+    let first_topic = "Insect appreciation and identification assistance".to_string();
+
+    // Publish a post to set the topic for the "entomology" channel.
+    let first_topic_hash = cable.post_topic(&channel, &first_topic).await?;
+
+    /* THIRD REQUEST */
+
+    // Generate a novel request ID.
+    let (_req_id, req_id_bytes) = cable.new_req_id().await?;
+
+    // Create a channel state request.
+    let channel_state_req =
+        Message::channel_state_request(CIRCUIT_ID, req_id_bytes, TTL, channel.clone(), 0);
+    let req_bytes = channel_state_req.to_bytes()?;
+
+    // Write the request bytes to the stream.
+    stream.write_all(&req_bytes).await?;
+
+    // Sleep briefly to allow time for the cable manager to respond.
+    let five_millis = Duration::from_millis(5);
+    thread::sleep(five_millis);
+
+    // Read the response from the stream.
+    let mut res_bytes = [0u8; 1024];
+    let _n = stream.read(&mut res_bytes).await?;
+
+    // Ensure that a hash response was returned by the listening peer.
+    let (_bytes_len, msg) = Message::from_bytes(&res_bytes)?;
+    assert_eq!(msg.message_type(), HASH_RESPONSE);
+
+    if let MessageBody::Response { body } = msg.body {
+        if let ResponseBody::Hash { hashes } = body {
+            // Two post hashes should be returned (one for join / leave and one
+            // for the latest topic).
+            assert_eq!(hashes.len(), 2);
+            // Ensure the first hash matches the hash of the recent leave post.
+            assert_eq!(hashes[0], leave_post_hash);
+            // Ensure the second hash matches the hash of the first topic post.
+            assert_eq!(hashes[1], first_topic_hash);
+        }
+    }
+
+    let second_topic =
+        "Insect appreciation; please don't ask for identification assistance".to_string();
+
+    // Publish a post to (re)set the topic for the "entomology" channel.
+    let second_topic_hash = cable.post_topic(&channel, &second_topic).await?;
+
+    /* FOURTH REQUEST */
+
+    // Generate a novel request ID.
+    let (_req_id, req_id_bytes) = cable.new_req_id().await?;
+
+    // Create a channel state request.
+    let channel_state_req =
+        Message::channel_state_request(CIRCUIT_ID, req_id_bytes, TTL, channel.clone(), 0);
+    let req_bytes = channel_state_req.to_bytes()?;
+
+    // Write the request bytes to the stream.
+    stream.write_all(&req_bytes).await?;
+
+    // Sleep briefly to allow time for the cable manager to respond.
+    let five_millis = Duration::from_millis(5);
+    thread::sleep(five_millis);
+
+    // Read the response from the stream.
+    let mut res_bytes = [0u8; 1024];
+    let _n = stream.read(&mut res_bytes).await?;
+
+    // Ensure that a hash response was returned by the listening peer.
+    let (_bytes_len, msg) = Message::from_bytes(&res_bytes)?;
+    assert_eq!(msg.message_type(), HASH_RESPONSE);
+
+    if let MessageBody::Response { body } = msg.body {
+        if let ResponseBody::Hash { hashes } = body {
+            // Two post hashes should be returned (one for join / leave and one
+            // for the latest topic).
+            assert_eq!(hashes.len(), 2);
+            // Ensure the first hash matches the hash of the recent leave post.
+            assert_eq!(hashes[0], leave_post_hash);
+            // Ensure the second hash matches the hash of the second topic post.
+            assert_eq!(hashes[1], second_topic_hash);
+        }
+    }
+
+    // Delete the second (most recent) topic post for the "entomology" channel.
+    let _delete_topic_hash = cable.post_delete(vec![second_topic_hash]).await?;
+
+    /* FOURTH REQUEST */
+
+    // Generate a novel request ID.
+    let (_req_id, req_id_bytes) = cable.new_req_id().await?;
+
+    // Create a channel state request.
+    let channel_state_req =
+        Message::channel_state_request(CIRCUIT_ID, req_id_bytes, TTL, channel.clone(), 0);
+    let req_bytes = channel_state_req.to_bytes()?;
+
+    // Write the request bytes to the stream.
+    stream.write_all(&req_bytes).await?;
+
+    // Sleep briefly to allow time for the cable manager to respond.
+    let five_millis = Duration::from_millis(5);
+    thread::sleep(five_millis);
+
+    // Read the response from the stream.
+    let mut res_bytes = [0u8; 1024];
+    let _n = stream.read(&mut res_bytes).await?;
+
+    // Ensure that a hash response was returned by the listening peer.
+    let (_bytes_len, msg) = Message::from_bytes(&res_bytes)?;
+    assert_eq!(msg.message_type(), HASH_RESPONSE);
+
+    if let MessageBody::Response { body } = msg.body {
+        if let ResponseBody::Hash { hashes } = body {
+            // Two post hashes should be returned (one for join / leave and one
+            // for the latest topic).
+            assert_eq!(hashes.len(), 2);
+            // Ensure the first hash matches the hash of the recent leave post.
+            assert_eq!(hashes[0], leave_post_hash);
+            // Ensure the second hash matches the hash of the first topic post.
+            assert_eq!(hashes[1], first_topic_hash);
+        }
+    }
+
+    Ok(())
+}

--- a/cable_core/tests/channel_state.rs
+++ b/cable_core/tests/channel_state.rs
@@ -13,6 +13,33 @@
 //!
 //! 2) Send a channel state request for the "entomology" channel. Ensure that
 //! a single hash is returned and that it matches the hash of the join post.
+//!
+//! 3) Publish a leave post to the "entomology" channel.
+//!
+//! 4) Send a channel state request for the "entomology" channel. Ensure that
+//! a single hash is returned and that it matches the hash of the leave post.
+//!
+//! 5) Publish a topic post to the "entomology" channel.
+//!
+//! 6) Send a channel state request for the "entomology" channel. Ensure that
+//! two hashes are returned: one matcing the hash of the leave post and one
+//! matching the hash of the topic post.
+//!
+//! 7) Publish a second topic post to the "entomology" channel.
+//!
+//! 8) Send a channel state request for the "entomology" channel. Ensure that
+//! two hashes are returned: one matching the hash of the leave post and one
+//! matching the hash of the second topic post.
+//!
+//! 9) Publish a delete post with the hash of the second topic post.
+//!
+//! 10) Send a channel state request for the "entomology" channel. Ensure that
+//! two hashes are returned: one matching the hash of the leave post and one
+//! matching the hash of the first topic post.
+
+// TODO: Update this test suite once live request handling is in place for
+// channel state requests (like it currently is for channel time range
+// requests).
 
 use std::{thread, time::Duration};
 
@@ -214,6 +241,11 @@ async fn channel_state_request_response() -> Result<(), Error> {
         }
     }
 
+    // Sleep briefly to ensure that the second topic post has a timestamp
+    // larger than the first.
+    let one_second = Duration::from_millis(1000);
+    thread::sleep(one_second);
+
     let second_topic =
         "Insect appreciation; please don't ask for identification assistance".to_string();
 
@@ -259,6 +291,10 @@ async fn channel_state_request_response() -> Result<(), Error> {
 
     // Delete the second (most recent) topic post for the "entomology" channel.
     let _delete_topic_hash = cable.post_delete(vec![second_topic_hash]).await?;
+
+    // Sleep briefly to allow time for the deletion to occur.
+    let five_millis = Duration::from_millis(5);
+    thread::sleep(five_millis);
 
     /* FOURTH REQUEST */
 

--- a/cable_core/tests/channel_state.rs
+++ b/cable_core/tests/channel_state.rs
@@ -60,7 +60,7 @@ use async_std::{
 use cable::{
     constants::{HASH_RESPONSE, NO_CIRCUIT},
     message::{MessageBody, ResponseBody},
-    ChannelOptions, Error, Message,
+    Error, Message,
 };
 use desert::{FromBytes, ToBytes};
 use futures::{AsyncReadExt, AsyncWriteExt};
@@ -78,14 +78,6 @@ const TTL: u8 = 1;
 // test run.
 fn init() {
     let _ = env_logger::builder().is_test(false).try_init();
-}
-
-// Get the current system time in seconds since the UNIX epoch.
-fn now() -> u64 {
-    std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_secs()
 }
 
 #[async_std::test]

--- a/cable_core/tests/channel_time_range.rs
+++ b/cable_core/tests/channel_time_range.rs
@@ -5,7 +5,7 @@
 //!
 //! Run the test with debug logging enabled in a terminal:
 //!
-//! `RUST_LOG=debug cargo test channel_time_range`
+//! `RUST_LOG=debug cargo test channel_time_range_request_response`
 //!
 //! An outline of the actions taken in this test:
 //!
@@ -72,7 +72,7 @@ fn now() -> u64 {
 }
 
 #[async_std::test]
-async fn request_response() -> Result<(), Error> {
+async fn channel_time_range_request_response() -> Result<(), Error> {
     init();
 
     // Create a store and a cable manager.


### PR DESCRIPTION
This is a large PR that bundles together most of the functionality required to store channel-related state (as well as cabal-wide state, e.g. `post/info`), to update stores when handling `post/delete` posts and to respond correctly to channel state requests.

Most of the work in this PR is reflected in the `channel_state.rs` integration test in `cable_core`.

There is quite a bit of clean-up and polishing to be done still. For example, many store methods unnecessarily return `Result` types. I'm aiming to tackle this and related issues in future PRs.