### PR TITLE
Live request and timestamp improvements

### DIFF
--- a/cable/src/message.rs
+++ b/cable/src/message.rs
@@ -182,7 +182,33 @@ impl Message {
 /// Print a message with byte arrays formatted as hex strings.
 impl fmt::Display for Message {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{{ {}, {} }}", &self.header, &self.body)
+        match &self.header.msg_type {
+            0 => write!(f, "HashResponse {{ {}, {} }}", &self.header, &self.body),
+            1 => write!(f, "PostResponse {{ {}, {} }}", &self.header, &self.body),
+            2 => write!(f, "PostRequest {{ {}, {} }}", &self.header, &self.body),
+            3 => write!(f, "CancelRequest {{ {}, {} }}", &self.header, &self.body),
+            4 => write!(
+                f,
+                "ChannelTimeRangeRequest {{ {}, {} }}",
+                &self.header, &self.body
+            ),
+            5 => write!(
+                f,
+                "ChannelStateRequest {{ {}, {} }}",
+                &self.header, &self.body
+            ),
+            6 => write!(
+                f,
+                "ChannelListRequest {{ {}, {} }}",
+                &self.header, &self.body
+            ),
+            7 => write!(
+                f,
+                "ChannelListResponse {{ {}, {} }}",
+                &self.header, &self.body
+            ),
+            _ => write!(f, "Unknown {{ {}, {} }}", &self.header, &self.body),
+        }
     }
 }
 

--- a/cable/src/post.rs
+++ b/cable/src/post.rs
@@ -337,7 +337,15 @@ impl Post {
 /// Print a post with byte arrays formatted as hex strings.
 impl fmt::Display for Post {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{{ {}, {} }}", &self.header, &self.body)
+        match &self.header.post_type {
+            0 => write!(f, "post/text {{ {}, {} }}", &self.header, &self.body),
+            1 => write!(f, "post/delete {{ {}, {} }}", &self.header, &self.body),
+            2 => write!(f, "post/info {{ {}, {} }}", &self.header, &self.body),
+            3 => write!(f, "post/topic {{ {}, {} }}", &self.header, &self.body),
+            4 => write!(f, "post/join {{ {}, {} }}", &self.header, &self.body),
+            5 => write!(f, "post/leave {{ {}, {} }}", &self.header, &self.body),
+            _ => write!(f, "post/unknown {{ {}, {} }}", &self.header, &self.body),
+        }
     }
 }
 

--- a/cable_core/Cargo.toml
+++ b/cable_core/Cargo.toml
@@ -7,9 +7,10 @@ edition = "2021"
 async-std = { version = "1.12.0", features = ["attributes","unstable"] }
 async-trait = "0.1.71"
 cable = { path = "../cable" }
+desert = { path = "../desert" }
 fastrand = "2.0.0"
 futures = "0.3.28"
-desert = { path = "../desert" }
+hex = "0.4.3"
 length-prefixed-stream = { path = "../length_prefixed_stream" }
 log = "0.4.19"
 signature = "2.1.0"
@@ -18,4 +19,3 @@ sodiumoxide = "0.2.7"
 [dev-dependencies]
 argmap = "1.1.2"
 env_logger = "0.10.0"
-hex = "0.4.3"

--- a/cable_core/src/manager.rs
+++ b/cable_core/src/manager.rs
@@ -80,6 +80,17 @@ impl RequestOrigin {
     }
 }
 
+/// Generate a timestamp for the current time.
+fn now() -> Result<u64, Error> {
+    let timestamp = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)?
+        .as_millis()
+        // Convert from u128 to u64.
+        .try_into()?;
+
+    Ok(timestamp)
+}
+
 /// The manager for a single cable instance.
 #[derive(Clone)]
 pub struct CableManager<S: Store> {
@@ -460,11 +471,7 @@ where
         } else {
             vec![]
         };
-        let timestamp = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)?
-            .as_millis()
-            // Convert from u128 to u64.
-            .try_into()?;
+        let timestamp = now()?;
 
         Ok((public_key, links, timestamp))
     }
@@ -492,11 +499,7 @@ where
     pub async fn post_delete(&mut self, hashes: Vec<Hash>) -> Result<Hash, Error> {
         let public_key = self.get_public_key().await?;
         let links = vec![];
-        let timestamp = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)?
-            .as_millis()
-            // Convert from u128 to u64.
-            .try_into()?;
+        let timestamp = now()?;
 
         // Add the hashes to the store of deleted posts.
         //
@@ -519,11 +522,7 @@ where
     pub async fn post_info_name(&mut self, username: &str) -> Result<Hash, Error> {
         let public_key = self.get_public_key().await?;
         let links = vec![];
-        let timestamp = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)?
-            .as_millis()
-            // Convert from u128 to u64.
-            .try_into()?;
+        let timestamp = now()?;
 
         let name_info = UserInfo::name(username)?;
 

--- a/cable_core/src/manager.rs
+++ b/cable_core/src/manager.rs
@@ -281,10 +281,12 @@ where
             task::spawn(async move {
                 // Listen for incoming locally-generated messages.
                 while let Ok(msg) = recv.recv().await {
-                    debug!("Wrote a message to the TCP stream: {}", msg);
+                    let msg_bytes = &msg.to_bytes()?;
 
                     // Write the message to the stream.
-                    stream_c.write_all(&msg.to_bytes()?).await?;
+                    stream_c.write_all(msg_bytes).await?;
+
+                    debug!("Wrote a message to the TCP stream: {}", msg,);
                 }
 
                 // Type inference fails without binding concretely to `Result`.
@@ -307,7 +309,7 @@ where
             // Deserialize the received message.
             let (_, msg) = Message::from_bytes(&buf)?;
 
-            debug!("Received a message from the TCP stream: {}", msg);
+            debug!("Received a message from the TCP stream: {}", msg,);
 
             let mut this = self.clone();
             task::spawn(async move {
@@ -420,8 +422,6 @@ where
                     }
                 }
                 if *ttl == 0 {
-                    debug!("Removing request {:?} from outbound requests...", req_id);
-
                     // The TTL for this request has been exhausted.
                     self.outbound_requests.write().await.remove(req_id);
                 } else {
@@ -462,7 +462,9 @@ where
         };
         let timestamp = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)?
-            .as_secs();
+            .as_millis()
+            // Convert from u128 to u64.
+            .try_into()?;
 
         Ok((public_key, links, timestamp))
     }
@@ -492,7 +494,9 @@ where
         let links = vec![];
         let timestamp = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)?
-            .as_secs();
+            .as_millis()
+            // Convert from u128 to u64.
+            .try_into()?;
 
         // Add the hashes to the store of deleted posts.
         //
@@ -517,7 +521,9 @@ where
         let links = vec![];
         let timestamp = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)?
-            .as_secs();
+            .as_millis()
+            // Convert from u128 to u64.
+            .try_into()?;
 
         let name_info = UserInfo::name(username)?;
 
@@ -617,6 +623,11 @@ where
 
                 match live_request {
                     LiveRequest::ChannelState(req_id, req_channel) => {
+                        debug!(
+                            "Matched channel state live request: {}",
+                            hex::encode(req_id)
+                        );
+
                         // Only send hashes if the channel of the post which invoked
                         // the call to `send_post_hashes()` matches the channel of
                         // the peer request.
@@ -681,6 +692,11 @@ where
                         }
                     }
                     LiveRequest::ChannelTimeRange(req_id, channel_opts) => {
+                        debug!(
+                            "Matched channel time range live request: {}",
+                            hex::encode(req_id)
+                        );
+
                         // Only send hashes if the channel of the post which invoked
                         // the call to `send_post_hashes()` matches the channel of
                         // the peer request.
@@ -692,7 +708,7 @@ where
                             while let Some(result) = stream.next().await {
                                 hashes.push(result?);
                                 // Break once the request limit has been reached.
-                                if hashes.len() as u64 >= limit {
+                                if limit != 0 && hashes.len() as u64 >= limit {
                                     break;
                                 }
                             }
@@ -701,10 +717,15 @@ where
                             drop(stream);
 
                             // Construct a new hash response message.
-                            let response = Message::hash_response(NO_CIRCUIT, *req_id, hashes);
+                            let response =
+                                Message::hash_response(NO_CIRCUIT, *req_id, hashes.clone());
 
-                            // Send the response to the peer.
-                            self.send(*peer_id, &response).await?;
+                            // Only send a response if there are post hashes matching
+                            // the given request parameters.
+                            if !hashes.is_empty() {
+                                // Send the response to the peer.
+                                self.send(*peer_id, &response).await?;
+                            }
                         }
                     }
                 }
@@ -811,6 +832,7 @@ where
                     }
 
                     let channel_opts = ChannelOptions::new(channel, *time_start, *time_end, *limit);
+
                     let n_limit = (*limit).min(4096);
 
                     let mut hashes = vec![];
@@ -819,8 +841,12 @@ where
                     // Iterate over the hashes in the stream.
                     while let Some(result) = stream.next().await {
                         hashes.push(result?);
-                        // Break out of the loop once the requested limit is met.
-                        if hashes.len() as u64 >= n_limit {
+                        // Break out of the loop once the requested limit is
+                        // met.
+                        //
+                        // A limit of 0 means there is no limit on the number
+                        // of hashes that may be returned.
+                        if n_limit != 0 && hashes.len() as u64 >= n_limit {
                             break;
                         }
                     }
@@ -828,7 +854,7 @@ where
                     // call to `self.send()` (immutable borrow).
                     drop(stream);
 
-                    let response = Message::hash_response(circuit_id, req_id, hashes);
+                    let response = Message::hash_response(circuit_id, req_id, hashes.clone());
 
                     // Add the peer and request ID to the request tracker if
                     // the end time has been set to 0 (i.e. keep this request
@@ -838,13 +864,23 @@ where
 
                         let mut live_requests = self.live_requests.write().await;
                         if let Some(peer_requests) = live_requests.get_mut(&peer_id) {
+                            // TODO: Only push if `peer_requests` does not
+                            // already contain this request.
                             peer_requests.push(live_request);
                         } else {
                             live_requests.insert(peer_id, vec![live_request]);
                         }
-                    }
 
-                    self.send(peer_id, &response).await?;
+                        // Only send a response if there are post hashes matching
+                        // the given request parameters.
+                        if !hashes.is_empty() {
+                            self.send(peer_id, &response).await?
+                        }
+                    } else {
+                        // Send a hash response, even if there are no known
+                        // hashes matching the request parameters.
+                        self.send(peer_id, &response).await?
+                    }
                 }
                 RequestBody::ChannelState { channel, future } => {
                     debug!("Handling channel state request...");
@@ -871,12 +907,29 @@ where
                         hashes.push(topic_hash)
                     }
 
-                    let response = Message::hash_response(circuit_id, req_id, hashes);
+                    let response = Message::hash_response(circuit_id, req_id, hashes.clone());
 
-                    // Add the peer and request ID to the request tracker if
-                    // the future field has been set to 1 (i.e. keep this request
-                    // alive and send new messages as they become available).
-                    if *future == 1 {
+                    // Send only the latest known hashes; do not keep the
+                    // request alive after responding.
+                    if *future == 0 {
+                        if !hashes.is_empty() {
+                            // Send the known hashes.
+                            self.send(peer_id, &response).await?;
+
+                            // Compost and send an empty hash response to
+                            // terminate the request.
+                            let closing_response =
+                                Message::hash_response(circuit_id, req_id, Vec::new());
+                            self.send(peer_id, &closing_response).await?;
+                        } else {
+                            // Send the empty hash response to terminate the
+                            // request.
+                            self.send(peer_id, &response).await?;
+                        }
+                    } else if *future == 1 {
+                        // Add the peer and request ID to the request tracker if
+                        // the future field has been set to 1 (i.e. keep this request
+                        // alive and send new messages as they become available).
                         let live_request = LiveRequest::ChannelState(req_id, channel.to_string());
 
                         let mut live_requests = self.live_requests.write().await;
@@ -885,9 +938,13 @@ where
                         } else {
                             live_requests.insert(peer_id, vec![live_request]);
                         }
-                    }
 
-                    self.send(peer_id, &response).await?
+                        // Only send a response if there are post hashes matching
+                        // the given request parameters.
+                        if !hashes.is_empty() {
+                            self.send(peer_id, &response).await?
+                        }
+                    }
 
                     /*
                     TODO: We will require channel state indexes before this
@@ -929,6 +986,7 @@ where
                         Vec::new()
                     };
 
+                    // Send a response, even if no channels are currently known.
                     let response = Message::channel_list_response(circuit_id, req_id, channels);
 
                     self.send(peer_id, &response).await?

--- a/cable_core/src/store.rs
+++ b/cable_core/src/store.rs
@@ -44,7 +44,7 @@ pub type NameHashMap = HashMap<PublicKey, BTreeMap<Timestamp, (Nickname, Hash)>>
 /// The key is an `Option` to allow for storage and retrieved of post types
 /// which do not have an associated channel; these posts are stored with a
 /// key of `None`.
-pub type PostMap = HashMap<Option<Channel>, BTreeMap<u64, Vec<(Post, Hash)>>>;
+pub type PostMap = HashMap<Option<Channel>, BTreeMap<Timestamp, Vec<(Post, Hash)>>>;
 
 /// A `HashMap` of channel topics with a key of channel name and a value of a
 /// `BTreeMap`. The `BTreeMap` has a key of timestamp and a value of a tuple
@@ -930,7 +930,6 @@ impl Store for MemoryStore {
         } else {
             // No posts have previously been stored for the
             // given channel.
-
             let mut post_map = BTreeMap::new();
             // Insert the post (as a `Vec`) into the `BTreeMap`,
             // using the timestamp as the key.


### PR DESCRIPTION
This PR introduces several improvements and bug fixes which came about through interoperability testing with the JS implementation of cable.

- An empty `HashResponse` is no longer returned to channel time range requests with `time_end == 0` if no posts matching the given options are currently known
- A `limit` bug has been fixed for channel time range responses
  - Previously, only a single hash was sent if `limit == 0`
- A helper function for determining the current timestamp has been added
- Improved logging of post and message types with humyn readable type
- Additional debug statements have been added
- Timestamps now correctly use milliseconds instead of seconds

This code has passed basic interoperability testing with the JS implementation, using `cabin` as the Rust client.