### PR TITLE
Perform validation of post text, channel name and topic

### DIFF
--- a/cable/src/error.rs
+++ b/cable/src/error.rs
@@ -27,9 +27,10 @@ pub enum CableErrorKind {
     NoneError { context: String },
     PostWriteUnrecognizedType { post_type: u64 },
     PostHashingFailed {},
-    UsernameLengthIncorrect { name: String, len: usize },
     ChannelLengthIncorrect { channel: String, len: usize },
+    TextLengthIncorrect { text: String, len: usize },
     TopicLengthIncorrect { topic: String, len: usize },
+    UsernameLengthIncorrect { name: String, len: usize },
 }
 
 impl CableErrorKind {
@@ -95,13 +96,6 @@ impl std::fmt::Display for CableError {
             CableErrorKind::PostWriteUnrecognizedType { post_type } => {
                 write![f, "cannot write unrecognized post_type={}", post_type]
             }
-            CableErrorKind::UsernameLengthIncorrect { name, len } => {
-                write![
-                    f,
-                    "expected username between 1 and 32 codepoints; name `{}` is {} codepoints",
-                    name, len
-                ]
-            }
             CableErrorKind::ChannelLengthIncorrect { channel, len } => {
                 write![
                     f,
@@ -109,11 +103,25 @@ impl std::fmt::Display for CableError {
                     channel, len
                 ]
             }
+            CableErrorKind::TextLengthIncorrect { text, len } => {
+                write![
+                    f,
+                    "expected text of 4096 bytes or less; text `{}` is {} bytes",
+                    text, len
+                ]
+            }
             CableErrorKind::TopicLengthIncorrect { topic, len } => {
                 write![
                     f,
                     "expected topic between 0 and 512 codepoints; topic `{}` is {} codepoints",
                     topic, len
+                ]
+            }
+            CableErrorKind::UsernameLengthIncorrect { name, len } => {
+                write![
+                    f,
+                    "expected username between 1 and 32 codepoints; name `{}` is {} codepoints",
+                    name, len
                 ]
             }
         }

--- a/cable/src/post.rs
+++ b/cable/src/post.rs
@@ -549,6 +549,8 @@ impl FromBytes for Post {
 
                 // Read the text bytes and increment the offset.
                 let text = String::from_utf8(buf[offset..offset + text_len as usize].to_vec())?;
+                // Validate the byte length of the text.
+                validation::validate_text(&text)?;
                 offset += text_len as usize;
 
                 PostBody::Text { channel, text }

--- a/cable/src/validation.rs
+++ b/cable/src/validation.rs
@@ -18,6 +18,22 @@ pub fn validate_channel(channel: &String) -> Result<(), Error> {
     Ok(())
 }
 
+/// Validate the length of a post's text (less than or equal to 4096 bytes).
+pub fn validate_text(text: &String) -> Result<(), Error> {
+    // Determine the length of the given post text in bytes.
+    let text_len = text.len();
+    // The text must not exceed 4096 bytes.
+    if text_len > 4096 {
+        return CableErrorKind::TextLengthIncorrect {
+            text: text.to_owned(),
+            len: text_len,
+        }
+        .raise();
+    }
+
+    Ok(())
+}
+
 /// Validate the length of a topic name (1 to 512 UTF-8 codepoints).
 pub fn validate_topic(topic: &String) -> Result<(), Error> {
     // Determine the length of the given channel topic in UTF-8 codepoints.


### PR DESCRIPTION
This PR adds a validation function for `post/text` text length and performs validation of text, channel name and topic before publishing a post and when decoding a post from bytes.

I've also included a fixed range match for `get_posts()` which was mistakenly omitted from the previous PR.